### PR TITLE
Add Mostly Stride 1 Pattern

### DIFF
--- a/include/sgbuf.h
+++ b/include/sgbuf.h
@@ -68,6 +68,8 @@ void wrap_indices(sgIdx_t *idx, size_t len, size_t worksets, size_t stride, size
  *  @param host_ptr The location from which to copy the data from, if not null and the proper flags are set. 
  */
 
+void ms1_indices(sgIdx_t *idx, size_t len, size_t worksets, size_t run, size_t gap);
+
 #ifdef USE_OPENCL
 //TODO: why is it a void*? 
 cl_mem clCreateBufferSafe(cl_context context, cl_mem_flags flags, size_t size, void *host_ptr);

--- a/src/main.c
+++ b/src/main.c
@@ -47,9 +47,12 @@ size_t N = 100;
 size_t workers = 1;
 size_t vector_len = 1;
 size_t local_work_size = 1;
+size_t ms1_gap = 0; 
+size_t ms1_run = 0;
 
 unsigned int shmem = 0;
 int random_flag = 0;
+int ms1_flag = 0;
 
 int json_flag = 0, validate_flag = 0, print_header_flag = 1;
 
@@ -276,12 +279,25 @@ int main(int argc, char **argv)
     //linear_indices(si.host_ptr, si.len, worksets, source.len / si.len, random_flag);
     //linear_indices(ti.host_ptr, ti.len, worksets, target.len / ti.len, random_flag);
 
-    if (wrap > 1) {
-        wrap_indices(si.host_ptr, si.len, worksets, si.stride, wrap);
-        wrap_indices(ti.host_ptr, ti.len, worksets, ti.stride, wrap);
+    if (ms1_indices) {
+        if (kernel == SCATTER) {
+            linear_indices(si.host_ptr, si.len, worksets, 1, 0);
+            ms1_indices(ti.host_ptr, ti.len, worksets, ms1_run, ms1_gap);
+        }else if (kernel == GATHER) {
+            ms1_indices(si.host_ptr, si.len, worksets, ms1_run, ms1_gap);
+            linear_indices(ti.host_ptr, ti.len, worksets, 1, 0);
+        } else {
+            printf("MS1 pattern is only supported for scatter and gather\n");
+            exit(1);
+        }
     } else {
-        linear_indices(si.host_ptr, si.len, worksets, si.stride, random_flag);
-        linear_indices(ti.host_ptr, ti.len, worksets, ti.stride, random_flag);
+        if (wrap > 1) {
+            wrap_indices(si.host_ptr, si.len, worksets, si.stride, wrap);
+            wrap_indices(ti.host_ptr, ti.len, worksets, ti.stride, wrap);
+        } else {
+            linear_indices(si.host_ptr, si.len, worksets, si.stride, random_flag);
+            linear_indices(ti.host_ptr, ti.len, worksets, ti.stride, random_flag);
+        }
     }
 
     /*

--- a/src/main.c
+++ b/src/main.c
@@ -279,7 +279,7 @@ int main(int argc, char **argv)
     //linear_indices(si.host_ptr, si.len, worksets, source.len / si.len, random_flag);
     //linear_indices(ti.host_ptr, ti.len, worksets, target.len / ti.len, random_flag);
 
-    if (ms1_indices) {
+    if (ms1_flag) {
         if (kernel == SCATTER) {
             linear_indices(si.host_ptr, si.len, worksets, 1, 0);
             ms1_indices(ti.host_ptr, ti.len, worksets, ms1_run, ms1_gap);

--- a/src/parse-args.c
+++ b/src/parse-args.c
@@ -317,7 +317,17 @@ void parse_args(int argc, char **argv)
     }
 
     //Check buffer lengths
-    if (generic_len <= 0){
+    if (generic_len && ms1_flag) {
+        if (kernel == SCATTER) {
+            source_len = generic_len;
+            target_len = (generic_len / ms1_run) * (ms1_run + ms1_gap);
+            index_len = generic_len;
+        } else if (kernel == GATHER) {
+            target_len = generic_len;
+            source_len = (generic_len / ms1_run) * (ms1_run + ms1_gap);
+            index_len = generic_len;
+        }
+    } else if (generic_len <= 0){
 
         if (source_len <= 0 && target_len <= 0 && index_len <= 0) {
             error ("Please specifiy at least one of : src_len, target_len, idx_len", 1);

--- a/src/parse-args.c
+++ b/src/parse-args.c
@@ -12,12 +12,15 @@
 #include "cuda-backend.h"
 #endif
 
-#define SOURCE     1000
-#define TARGET     1001 
-#define INDEX      1002
-#define BLOCK      1003
-#define SEED       1004
-#define VALIDATE   1005
+#define SOURCE      1000
+#define TARGET      1001 
+#define INDEX       1002
+#define BLOCK       1003
+#define SEED        1004
+#define VALIDATE    1005
+#define MS1_PATTERN 1006
+#define MS1_GAP     1007
+#define MS1_RUN     1008
 
 #define INTERACTIVE "INTERACTIVE"
 
@@ -37,6 +40,9 @@ extern size_t R;
 extern size_t N;
 extern size_t local_work_size;
 extern size_t workers;
+extern size_t ms1_gap;
+extern size_t ms1_run;
+extern int ms1_flag;
 extern int json_flag;
 extern int validate_flag;
 extern int print_header_flag;
@@ -108,6 +114,9 @@ void parse_args(int argc, char **argv)
         {"sparsity",        required_argument, NULL, 's'},
         {"local-work-size", required_argument, NULL, 'z'},
         {"shared-mem",      required_argument, NULL, 'm'},
+        {"ms1-pattern",     no_argument,       NULL, MS1_PATTERN},
+        {"ms1-gap",         required_argument, NULL, MS1_GAP},
+        {"ms1-run",         required_argument, NULL, MS1_RUN},
         {"supress-errors",  no_argument,       NULL, 'q'},
         {"random",          no_argument,       NULL, 'y'},
         {"validate",        no_argument, &validate_flag, 1},
@@ -230,6 +239,15 @@ void parse_args(int argc, char **argv)
             case 'q':
                 err_file = fopen("/dev/null", "w");
                 break;
+            case MS1_PATTERN:
+                ms1_flag = 1;
+                break;
+            case MS1_RUN:
+                sscanf(optarg, "%zu", &ms1_run);
+                break;
+            case MS1_GAP:
+                sscanf(optarg, "%zu", &ms1_gap);
+                break;
             default:
                 break;
 
@@ -349,6 +367,11 @@ void parse_args(int argc, char **argv)
     if (workers < 1){
         error("Too few workers. Changing to 1.", 0);
         workers = 1;
+    }
+    
+    if(ms1_flag) {
+        assert(ms1_run > 0);
+        assert(ms1_gap > 0);
     }
 
     /* Seed rand */

--- a/src/sgbuf.c
+++ b/src/sgbuf.c
@@ -53,6 +53,19 @@ void wrap_indices(sgIdx_t *idx, size_t len, size_t worksets, size_t stride, size
     }
 }
 
+//Mostly Stride-1
+void ms1_indices(sgIdx_t *idx, size_t len, size_t worksets, size_t run, size_t gap){
+    sgIdx_t *idx_cur = idx;
+    for(size_t j = 0; j < worksets; j++){
+        for(size_t i = 0; i < len; i++){
+
+            idx_cur[i] = (i / run) * gap + (i % run);
+        }
+        idx_cur = idx_cur + len;
+    }
+
+}
+
 #ifdef USE_OPENCL
 cl_mem clCreateBufferSafe(cl_context context, cl_mem_flags flags, size_t size, void *host_ptr){
     cl_int err;


### PR DESCRIPTION
Preliminary support for the ms1 pattern. No accompanying scripts are provided. To use it, specify three command line parameters. 

--ms1-flag

--ms1-run=<# contiguous elements>

--ms1-gap=<# elements between blocks>

The only works for Gather and Scatter kernels. I feel the combined SG should probably be deprecated. 