### PR TITLE
Cleanup Command-line Arguments

### DIFF
--- a/cuda/cuda-backend.c
+++ b/cuda/cuda-backend.c
@@ -7,8 +7,8 @@
 #define cudaSilent(a) if(a!=cudaSuccess) exit(0);
 
 void create_dev_buffers_cuda(sgDataBuf* source, sgDataBuf* target, 
-                            sgIndexBuf* si, sgIndexBuf *ti, 
-                            size_t block_len){
+                            sgIndexBuf* si, sgIndexBuf *ti)
+{
     cudaError_t ret;
     ret = cudaMalloc((void **)&(source->dev_ptr_cuda), source->size); cudaSilent(ret);
     ret = cudaMalloc((void **)&(target->dev_ptr_cuda), target->size); cudaSilent(ret);

--- a/cuda/cuda-backend.h
+++ b/cuda/cuda-backend.h
@@ -6,15 +6,14 @@
 
 extern void my_kernel_wrapper(unsigned int dim, unsigned int* grid, unsigned int* block);
 
-extern float cuda_sg_wrapper(enum sg_kernel kernel, size_t block_len, 
+extern float cuda_sg_wrapper(enum sg_kernel kernel, 
                        size_t vector_len, 
                        uint dim, uint* grid, uint* block, 
                        double* target, double *source, 
                        long* ti, long* si, unsigned int shmem);
 
 void create_dev_buffers_cuda(sgDataBuf *source, sgDataBuf *targt, 
-                             sgIndexBuf *si, sgIndexBuf *ti, 
-                             size_t block_len);
+                             sgIndexBuf *si, sgIndexBuf *ti);
 
 int find_device_cuda(char *name);
 #endif

--- a/cuda/my_kernel.cu
+++ b/cuda/my_kernel.cu
@@ -107,7 +107,6 @@ extern "C" int translate_args(unsigned int dim, unsigned int* grid, unsigned int
 }
 
 extern "C" float cuda_sg_wrapper(enum sg_kernel kernel, 
-                                size_t block_len, 
                                 size_t vector_len, 
                                 uint dim, uint* grid, uint* block, 
                                 double* target, double *source, 

--- a/include/sgbuf.h
+++ b/include/sgbuf.h
@@ -27,7 +27,6 @@ typedef struct sgDataBuf_t{
     #endif    
     size_t len;         /**< The length of the buffers (in blocks) */
     size_t size;        /**< The size of the buffer (in bytes) */
-    size_t block_len;   /**< The length of a block (number of SGTYPEs in a workset */
 }sgDataBuf;
 
 /** @brief Describes a buffer object describing how data will be scattered/gathered */

--- a/opencl/ocl-backend.c
+++ b/opencl/ocl-backend.c
@@ -13,7 +13,7 @@ void initialize_dev_ocl(char* platform_string, char* device_string)
 
 }
 
-void create_dev_buffers_ocl(sgDataBuf *source, sgDataBuf *target, sgIndexBuf *si, sgIndexBuf *ti, size_t block_len)
+void create_dev_buffers_ocl(sgDataBuf *source, sgDataBuf *target, sgIndexBuf *si, sgIndexBuf *ti)
 {
 
         flags = CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR | CL_MEM_HOST_WRITE_ONLY;

--- a/opencl/ocl-backend.h
+++ b/opencl/ocl-backend.h
@@ -21,6 +21,6 @@
 
 void initialize_dev_ocl(char* platform_string, char* device_string);
 
-void create_dev_buffers_ocl(sgDataBuf *source, sgDataBuf *target, sgIndexBuf *si, sgIndexBuf *ti, size_t block_len);
+void create_dev_buffers_ocl(sgDataBuf *source, sgDataBuf *target, sgIndexBuf *si, sgIndexBuf *ti);
 
 #endif //end OCL_BACKEND

--- a/src/main.c
+++ b/src/main.c
@@ -41,7 +41,6 @@ char config_file[STRING_SIZE];
 size_t source_len;
 size_t target_len;
 size_t index_len;
-size_t block_len;
 size_t seed;
 size_t wrap = 1;
 size_t R = 10;
@@ -215,11 +214,6 @@ int main(int argc, char **argv)
    si.size     = si.len * sizeof(sgIdx_t);
    ti.size     = ti.len * sizeof(sgIdx_t);
 
-    /* This is the number of sgData_t's in a workset */
-    //TODO: remove since this is obviously useless
-    source.block_len = source.len;
-    target.block_len = target.len;
-
     /* Create the kernel */
     #ifdef USE_OPENCL
     if (backend == OPENCL) {
@@ -299,13 +293,13 @@ int main(int argc, char **argv)
     /* Create buffers on device and transfer data from host */
     #ifdef USE_OPENCL
     if (backend == OPENCL) {
-        create_dev_buffers_ocl(&source, &target, &si, &ti, block_len);
+        create_dev_buffers_ocl(&source, &target, &si, &ti);
     }
     #endif
 
     #ifdef USE_CUDA
     if (backend == CUDA) {
-        create_dev_buffers_cuda(&source, &target, &si, &ti, block_len);
+        create_dev_buffers_cuda(&source, &target, &si, &ti);
         cudaMemcpy(source.dev_ptr_cuda, source.host_ptr, source.size, cudaMemcpyHostToDevice);
         cudaMemcpy(si.dev_ptr_cuda, si.host_ptr, si.size, cudaMemcpyHostToDevice);
         cudaMemcpy(ti.dev_ptr_cuda, ti.host_ptr, ti.size, cudaMemcpyHostToDevice);
@@ -372,7 +366,7 @@ int main(int argc, char **argv)
             unsigned int grid[arr_len]  = {global_work_size/local_work_size};
             unsigned int block[arr_len] = {local_work_size};
             
-            float time_ms = cuda_sg_wrapper(kernel, block_len, vector_len, 
+            float time_ms = cuda_sg_wrapper(kernel, vector_len, 
                     arr_len, grid, block, target.dev_ptr_cuda, source.dev_ptr_cuda, 
                    ti.dev_ptr_cuda, si.dev_ptr_cuda, shmem); 
             cudaDeviceSynchronize();
@@ -463,23 +457,17 @@ int main(int argc, char **argv)
         switch (kernel) {
             case SG:
                 for (size_t i = 0; i < index_len; i++){
-                    for (size_t b = 0; b < block_len; b++) {
-                        target.host_ptr[ti.host_ptr[i+b]] = source.host_ptr[si.host_ptr[i+b]];
-                    }
+                    target.host_ptr[ti.host_ptr[i]] = source.host_ptr[si.host_ptr[i]];
                 }
                 break;
             case SCATTER:
                 for (size_t i = 0; i < index_len; i++){
-                    for (size_t b = 0; b < block_len; b++) {
-                        target.host_ptr[ti.host_ptr[i+b]] = source.host_ptr[i+b];
-                    }
+                    target.host_ptr[ti.host_ptr[i]] = source.host_ptr[i];
                 }
                 break;
             case GATHER:
                 for (size_t i = 0; i < index_len; i++){
-                    for (size_t b = 0; b < block_len; b++) {
-                        target.host_ptr[i+b] = source.host_ptr[si.host_ptr[i+b]];
-                    }
+                    target.host_ptr[i] = source.host_ptr[si.host_ptr[i]];
                 }
                 break;
         }

--- a/src/main.c
+++ b/src/main.c
@@ -44,7 +44,6 @@ size_t index_len;
 size_t seed;
 size_t wrap = 1;
 size_t R = 10;
-size_t N = 100;
 size_t workers = 1;
 size_t vector_len = 1;
 size_t local_work_size = 1;

--- a/src/parse-args.c
+++ b/src/parse-args.c
@@ -39,7 +39,6 @@ extern size_t wrap;
 extern size_t seed;
 extern size_t vector_len;
 extern size_t R;
-extern size_t N;
 extern size_t local_work_size;
 extern size_t workers;
 extern size_t ms1_gap;
@@ -101,14 +100,10 @@ void parse_args(int argc, char **argv)
         {"cl-device",       required_argument, NULL, 'd'},
         {"kernel-file",     required_argument, NULL, 'f'},
         {"kernel-name",     required_argument, NULL, 'k'},
-        {"source-len",      required_argument, NULL, SOURCE},
-        {"target-len",      required_argument, NULL, TARGET},
-        {"index-len",       required_argument, NULL, INDEX},
         {"seed",            required_argument, NULL, SEED},
         {"vector-len",      required_argument, NULL, 'v'},
         {"generic-len",     required_argument, NULL, 'l'},
         {"runs",            required_argument, NULL, 'R'},
-        {"loops",           required_argument, NULL, 'N'},
         {"workers",         required_argument, NULL, 'W'},
         {"wrap",            required_argument, NULL, 'w'},
         {"op",              required_argument, NULL, 'o'},
@@ -210,9 +205,6 @@ void parse_args(int argc, char **argv)
                 break;
             case 'R':
                 sscanf(optarg, "%zu", &R);
-                break;
-            case 'N':
-                sscanf(optarg, "%zu", &N);
                 break;
             case 'W':
                 sscanf(optarg, "%zu", &workers);

--- a/src/parse-args.c
+++ b/src/parse-args.c
@@ -35,7 +35,6 @@ extern char config_file[STRING_SIZE];
 extern size_t source_len;
 extern size_t target_len;
 extern size_t index_len;
-extern size_t block_len;
 extern size_t wrap;
 extern size_t seed;
 extern size_t vector_len;
@@ -80,7 +79,6 @@ void parse_args(int argc, char **argv)
     source_len = 0;
     target_len = 0;
     index_len  = 0;
-    block_len  = 1;
     seed       = time(NULL); 
     err_file   = stderr;
 
@@ -106,7 +104,6 @@ void parse_args(int argc, char **argv)
         {"source-len",      required_argument, NULL, SOURCE},
         {"target-len",      required_argument, NULL, TARGET},
         {"index-len",       required_argument, NULL, INDEX},
-        {"block-len",       required_argument, NULL, BLOCK},
         {"seed",            required_argument, NULL, SEED},
         {"vector-len",      required_argument, NULL, 'v'},
         {"generic-len",     required_argument, NULL, 'l'},
@@ -200,9 +197,6 @@ void parse_args(int argc, char **argv)
                 break;
             case INDEX:
                 sscanf(optarg, "%zu", &index_len);
-                break;
-            case BLOCK:
-                sscanf(optarg, "%zu", &block_len);
                 break;
             case SEED:
                 sscanf(optarg, "%zu", &seed);
@@ -380,9 +374,6 @@ void parse_args(int argc, char **argv)
         }
     }
 
-    if(block_len < 1){
-        error("Invalid block-len", 1);
-    }
     if (workers < 1){
         error("Too few workers. Changing to 1.", 0);
         workers = 1;

--- a/src/parse-args.c
+++ b/src/parse-args.c
@@ -249,6 +249,11 @@ void parse_args(int argc, char **argv)
 
     }
 
+    if (generic_len <= 0) {
+        error ("Length not specified. Default is 16 (elements)", 0);
+        generic_len = 16;
+    }
+
     /* Check argument coherency */
     if(backend == INVALID_BACKEND){
         if (sg_cuda_support()) {
@@ -311,7 +316,7 @@ void parse_args(int argc, char **argv)
     }
 
     //Check buffer lengths
-    if (generic_len && ms1_flag) {
+    if (ms1_flag) {
         if (kernel == SCATTER) {
             source_len = generic_len;
             target_len = (generic_len / ms1_run) * (ms1_run + ms1_gap);
@@ -321,35 +326,8 @@ void parse_args(int argc, char **argv)
             source_len = (generic_len / ms1_run) * (ms1_run + ms1_gap);
             index_len = generic_len;
         }
-    } else if (generic_len <= 0){
-
-        if (source_len <= 0 && target_len <= 0 && index_len <= 0) {
-            error ("Please specifiy at least one of : src_len, target_len, idx_len", 1);
-        }
-        if (source_len > 0 && target_len <= 0) {
-            target_len = source_len;
-        }
-        if (source_len > 0 && index_len <= 0) {
-            index_len = source_len;
-        }
-        if (target_len > 0 && source_len <= 0) {
-            source_len = target_len;
-        }
-        if (target_len > 0 && index_len <= 0) {
-            index_len = target_len;
-        }
-        if (index_len > 0 && source_len <= 0) {
-            source_len = index_len;
-        }
-        if (index_len > 0 && target_len <= 0) {
-            target_len = index_len;
-        }
     }
     else{
-        if (source_len > 0 || target_len > 0 || index_len > 0) {
-            error ("If you specify a generic length, source_len, target_len, and index_len will be ignored.", 0);
-        }
-
         index_len = generic_len;
         if (kernel == SCATTER) {
             target_len = generic_len * sparsity;

--- a/src/parse-args.c
+++ b/src/parse-args.c
@@ -22,7 +22,6 @@
 #define MS1_PATTERN 1006
 #define MS1_GAP     1007
 #define MS1_RUN     1008
-#define CONFIG_FILE 1009
 
 #define INTERACTIVE "INTERACTIVE"
 
@@ -113,7 +112,7 @@ void parse_args(int argc, char **argv)
         {"ms1-pattern",     no_argument,       NULL, MS1_PATTERN},
         {"ms1-gap",         required_argument, NULL, MS1_GAP},
         {"ms1-run",         required_argument, NULL, MS1_RUN},
-        {"config-file",     required_argument, NULL, CONFIG_FILE},
+        {"config-file",     required_argument, NULL, 't'},
         {"supress-errors",  no_argument,       NULL, 'q'},
         {"random",          no_argument,       NULL, 'y'},
         {"validate",        no_argument, &validate_flag, 1},
@@ -239,7 +238,7 @@ void parse_args(int argc, char **argv)
             case MS1_GAP:
                 sscanf(optarg, "%zu", &ms1_gap);
                 break;
-            case CONFIG_FILE:
+            case 't':
                 safestrcopy(config_file, optarg);
                 config_flag = 1;
                 break;

--- a/src/parse-args.c
+++ b/src/parse-args.c
@@ -107,7 +107,7 @@ void parse_args(int argc, char **argv)
         {"workers",         required_argument, NULL, 'W'},
         {"wrap",            required_argument, NULL, 'w'},
         {"op",              required_argument, NULL, 'o'},
-        {"sparsity",        required_argument, NULL, 's'},
+        {"uniform-stride",  required_argument, NULL, 's'},
         {"local-work-size", required_argument, NULL, 'z'},
         {"shared-mem",      required_argument, NULL, 'm'},
         {"ms1-pattern",     no_argument,       NULL, MS1_PATTERN},


### PR DESCRIPTION
This finishes removing the dense block parameter aka `B` from the code. It also removes a number of other command line arguments that have become unused in our testing and simplifies the logic in parse-args accordingly. 

Edit: This also adds a short argument for --trace-file , -t. 