### PR TITLE
Add thread-local state to mt rnd gen, parallelize random data fill.

### DIFF
--- a/src/mt19937-64.c
+++ b/src/mt19937-64.c
@@ -65,9 +65,9 @@
 
 
 /* The array for the state vector */
-static unsigned long long mt[NN]; 
+static __thread unsigned long long mt[NN]; 
 /* mti==NN+1 means mt[NN] is not initialized */
-static int mti=NN+1; 
+static __thread int mti=NN+1; 
 
 /* initializes mt[NN] with a seed */
 void init_genrand64(unsigned long long seed)

--- a/src/sgbuf.c
+++ b/src/sgbuf.c
@@ -1,12 +1,23 @@
 #include <stdio.h>
 #include <stdlib.h>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
 #include "sgtype.h"
 #include "sgbuf.h"
 #include "mt64.h"
 
 void random_data(sgData_t *buf, size_t len){
+#ifdef _OPENMP
+  int nt = omp_get_max_threads();
+#pragma omp parallel for num_threads(nt)
+  for(int i=0; i<nt; i++) {
+    init_genrand64(0x1337ULL + i);
+  }
+#pragma omp parallel for shared(buf,len) num_threads(nt)
+#endif
     for(size_t i = 0; i < len; i++){
-        buf[i] = rand() % 10; 
+        buf[i] = genrand64_int64() % 10;
     }
 }
 


### PR DESCRIPTION
This doesn't do much but speed up the init / fill of random data using pthreads and a thread-safe version of the MT rand gen code you already have. The other init slowdown does appear to be in the processing of the input config file's data. I can make that faster as well in another commit if you'd like.