### PR TITLE
Adding skip option (delta between G/S instructions), sundry fixups.

### DIFF
--- a/src/mt19937-64.c
+++ b/src/mt19937-64.c
@@ -109,7 +109,7 @@ unsigned long long genrand64_int64(void)
 {
     int i;
     unsigned long long x;
-    static unsigned long long mag01[2]={0ULL, MATRIX_A};
+    static __thread unsigned long long mag01[2]={0ULL, MATRIX_A};
 
     if (mti >= NN) { /* generate NN words at one time */
 

--- a/src/sgbuf.c
+++ b/src/sgbuf.c
@@ -19,7 +19,7 @@ void random_data(sgData_t *buf, size_t len){
     }
 #pragma omp parallel for shared(buf,len) num_threads(nt)
     for(size_t i = 0; i < len; i++){
-        buf[i] = genrand64_int64() % 10;
+        buf[i] = genrand64_int63() % 10;
     }
 }
 
@@ -103,7 +103,15 @@ size_t trace_indices( sgIdx_t *idx, size_t len, struct trace tr) {
         int i;
         for (i = 0; i < in.length ; i++) {
             if (i + cur < len) {
-                sidx[i+cur] = in.delta[i];
+#if 0
+	        // Skip first delta (i.e., between two SIMD instructions).
+	        if( i == 0 ) {
+		    sidx[i+cur] = 8;
+	        } else
+#endif
+	        {
+                    sidx[i+cur] = in.delta[i];
+	        }
             } else {
                 done = 1;
                 break;


### PR DESCRIPTION
This PR has a couple of fixups for things which I never hit as a problem yet, but seemed like they could be improved anyway. -- Also this shows an experimental option, disabled with "#if 0" in "sgbuf.c" which would discard the first delta from each G/S pattern entry; this is the delta between SIMD instructions. Enabling this option (skipping the first delta) makes the memory used substantially more consistent as well as often smaller. I, subjectively, have not seen a large change in reported kernel performance between the case of this being enabled vs. not.