### PR TITLE
Vrand

### DIFF
--- a/src/mt19937-64.c
+++ b/src/mt19937-64.c
@@ -109,7 +109,7 @@ unsigned long long genrand64_int64(void)
 {
     int i;
     unsigned long long x;
-    static unsigned long long mag01[2]={0ULL, MATRIX_A};
+    static __thread unsigned long long mag01[2]={0ULL, MATRIX_A};
 
     if (mti >= NN) { /* generate NN words at one time */
 

--- a/src/sgbuf.c
+++ b/src/sgbuf.c
@@ -172,6 +172,7 @@ size_t trace_indices( sgIdx_t *idx, size_t len, struct trace tr) {
       for(size_t p = 0; p < npages; p++) {
 	if( pages[p] == page ) {
 	  pidx = p;
+	  break;
 	}
       }
       if( pidx == -1 ) {

--- a/src/sgbuf.c
+++ b/src/sgbuf.c
@@ -19,7 +19,7 @@ void random_data(sgData_t *buf, size_t len){
     }
 #pragma omp parallel for shared(buf,len) num_threads(nt)
     for(size_t i = 0; i < len; i++){
-        buf[i] = genrand64_int64() % 10;
+        buf[i] = genrand64_int63() % 10;
     }
 }
 
@@ -103,7 +103,15 @@ size_t trace_indices( sgIdx_t *idx, size_t len, struct trace tr) {
         int i;
         for (i = 0; i < in.length ; i++) {
             if (i + cur < len) {
-                sidx[i+cur] = in.delta[i];
+#if 0
+	        // Skip first delta (i.e., between two SIMD instructions).
+	        if( i == 0 ) {
+		    sidx[i+cur] = 8;
+	        } else
+#endif
+	        {
+                    sidx[i+cur] = in.delta[i];
+	        }
             } else {
                 done = 1;
                 break;

--- a/src/sgbuf.c
+++ b/src/sgbuf.c
@@ -6,6 +6,7 @@
 #include "sgtype.h"
 #include "sgbuf.h"
 #include "mt64.h"
+#include "vrand.h"
 
 void random_data(sgData_t *buf, size_t len){
 #ifdef _OPENMP
@@ -80,7 +81,7 @@ void ms1_indices(sgIdx_t *idx, size_t len, size_t worksets, size_t run, size_t g
 
 }
 
-struct instruction get_random_instr (struct trace tr) {
+struct instruction get_random_instr_orig (struct trace tr) {
     double r = (double)rand() / (double)RAND_MAX;
     for (int i = 0; i < tr.length-1; i++) {
         if (tr.in[i].cpct > r) {
@@ -88,6 +89,27 @@ struct instruction get_random_instr (struct trace tr) {
         }
     }
     return tr.in[tr.length-1];
+}
+
+struct instruction get_random_instr(struct trace tr) 
+{
+  static int init = 0;
+  static dist_t *tr_dist;
+  
+  if( !init ) {
+    // This style of init will leak the dist_t when done..
+    vrand_init(0x1337ULL);
+    tr_dist = vrand_dist_alloc(tr.length);
+    double sum_pct = 0.0;
+    for(int i=0; i<tr.length; i++) {
+      tr_dist->p[i] = tr.in[i].pct;
+      sum_pct += tr_dist->p[i];
+    }
+    vrand_dist_init(tr_dist, sum_pct);
+    init = 1;
+  }
+
+  return tr.in[ vrand_dist(tr_dist) ];
 }
 
 //returns the size of the buffer required

--- a/src/vrand.c
+++ b/src/vrand.c
@@ -142,8 +142,8 @@ double vrand_double()
 /* Returns element from {0..d->n-1} according to d */
 unsigned int vrand_dist(dist_t *d)
 {
-  unsigned int p0 = vrand_double();
-  unsigned int p1 = vrand_double();
+  unsigned int p0 = vrand_uint();
+  unsigned int p1 = vrand_uint();
   unsigned int j  = p0 * d->m1;
 
   if ( (p1 * d->m2) < d->p[j] ) return j;

--- a/src/vrand.c
+++ b/src/vrand.c
@@ -1,0 +1,161 @@
+/*//////////////////////////////////////////////////////////////////////////////
+//
+// Implementation from:
+// "A linear algorithm for generating random numbers with a given distribution"
+// Software Engineering, IEEE Transactions (Volume:17, Issue: 9, pp. 972-975)
+// Vose, M.D. ; Dept. of Comput. Sci., Tennessee Univ., Knoxville, TN, USA 
+//
+///////////////////////////////////////////////////////////////////////////// */
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#define _VRAND_C
+#include "vrand.h"
+
+
+////////////////////////////////////////////////////////////
+
+
+static __thread unsigned int rndx, rtab[55];
+
+
+////////////////////////////////////////////////////////////
+
+
+static int nrndm()
+{
+  unsigned int k;
+  
+  for (k = 0; k < 24; k++) rtab[k] -= rtab[k+31];
+  for (k = 24; k < 55; k++) rtab[k] -= rtab[k-24];
+  return 0;
+}
+
+static void error_rnd(char *s)
+{
+  printf("%s\n",s);
+  exit(1);
+}
+
+
+////////////////////////////////////////////////////////////
+
+
+void vrand_init(unsigned int j)
+{
+  unsigned int h,i,k;
+  
+  for (rtab[54] = j |= (k = i = 1); i < 55; i++)
+    h = (21*i)%55, rtab[--h] = k, k = j - k, j = rtab[h];
+  while (i--){
+    for (k = 0; k < 24; k++) rtab[k] -= rtab[k+31];
+    for (k = 24; k < 55; k++) rtab[k] -= rtab[k-24];
+  }
+  rndx = 0;
+}
+
+dist_t *vrand_dist_alloc(unsigned int n)
+{
+  dist_t *d;
+  
+  if (!(d = (dist_t *) malloc(sizeof(dist_t))))
+    error_rnd("malloc (allocdist: d)");
+  d->n = n;
+  if (!(d->a = (int *)malloc(d->n * sizeof(int))))
+    error_rnd("malloc (allocdist: d->a)");
+  if (!(d->p = (double *)malloc(d->n * sizeof(double))))
+    error_rnd("malloc (allocdist: d->p)");
+  return d;
+}
+
+void vrand_dist_free(dist_t *d)
+{
+  free(d->a);
+  free(d->p);
+  free(d);
+}
+
+#define TWO_32   (4294967296.0)
+#define getsmall { while (p[j] >= q) if ((++j) == stop) goto end; t = j++; }
+#define getlarge while (p[k] < q) if ((++k) == stop) goto cleanup;
+
+/* Initialize the distribution d */
+dist_t *vrand_dist_init(dist_t *d, double s)
+{
+  /*
+    d->p must have d->n elements which sum to s on entry to initdist.
+    d->p and d->a are overwritten by the initialization process.
+  */
+  int j,k,t,stop,*a; double q,*p;
+  
+  stop = d->n, q = s/stop, j = k = 0;
+  
+  d->m1 = stop/TWO_32;
+  d->m2 = s/(stop * TWO_32);
+  
+  a = d->a;
+  p = d->p;
+  
+  getsmall; getlarge;
+  
+ loop:
+  
+  a[t] = k;
+  p[k] += p[t] - q;
+  
+  if (p[k] >= q) {
+    if (j == stop) goto end;
+    getsmall;
+    goto loop;
+  }
+  t = k++;
+  if (k == stop) goto cleanup;
+  if (j < k) getsmall;
+  getlarge;
+  goto loop;
+  
+ cleanup:
+  
+  a[t] = t;
+  while (j < stop) { a[j] = j; j++; }
+  
+ end:
+  return d;
+}
+
+#undef getsmall
+#undef getlarge
+
+#define rndm() ((++rndx>54)?rtab[rndx=nrndm()]:rtab[rndx])
+
+unsigned int vrand_uint()
+{
+  return rndm();
+}
+
+double vrand_double()
+{
+  return vrand_uint() / TWO_32;
+}
+
+/* Returns element from {0..d->n-1} according to d */
+unsigned int vrand_dist(dist_t *d)
+{
+  unsigned int p0 = vrand_double();
+  unsigned int p1 = vrand_double();
+  unsigned int j  = p0 * d->m1;
+
+  if ( (p1 * d->m2) < d->p[j] ) return j;
+  return d->a[j];
+}
+
+
+////////////////////////////////////////////////////////////
+
+
+#undef rndm
+#undef TWO_32
+
+
+////////////////////////////////////////////////////////////

--- a/src/vrand.h
+++ b/src/vrand.h
@@ -1,0 +1,31 @@
+#ifndef _VRAND_H
+#define _VRAND_H
+
+
+// For generating random number i with probability ->p[i].
+typedef struct st_dist
+{
+  double *p;
+  int    *a;
+  int     n;
+  double  m1;
+  double  m2;
+} dist_t;
+
+
+// Interface
+#ifndef _VRAND_C
+// Basic interface.
+extern void         vrand_init  (unsigned int j);
+extern unsigned int vrand_uint  ();
+extern double       vrand_double();
+// Interface for sampling from arbitraty distributions:
+// select elements from {0..d->n-1} according to d.
+extern dist_t*      vrand_dist_alloc(unsigned int n);
+extern dist_t*      vrand_dist_init (dist_t *d, double s);
+extern unsigned int vrand_dist      (dist_t *d);
+extern void         vrand_dist_free (dist_t *d);
+#endif
+
+
+#endif


### PR DESCRIPTION
This contains the same content as my last pull request (option to skip the first delta in each G/S entry), and also adds "vrand.[ch]" connected in "sgbuf.c" to improve speed of selecting random patterns / instructions from the distribution of available patterns.  For some cases this doesn't make a large difference, but on at least one example with Lulesh, I see times going from 70s to less than 1s.