### PR TITLE
add posix_memalign workaround for missing aligned_alloc

### DIFF
--- a/src/sp_alloc.c
+++ b/src/sp_alloc.c
@@ -34,7 +34,13 @@ void check_safe_mult(size_t a, size_t b) {
 void *sp_malloc (size_t size, size_t count, size_t align) {
     check_safe_mult(size, count);
     check_size(size*count);
+#ifdef USE_POSIX_MEMALIGN
+    void *ptr = NULL;
+    int ret = posix_memalign (&ptr,align,size*count);
+    if (ret!=0) ptr = NULL;
+#else
     void *ptr = aligned_alloc (align, size*count);
+#endif
     if (!ptr) {
         printf("Attepmted to allocate %zu bytes (%zu * %zu)\n", size*count, size , count);
         error("Error: failed to allocate memory", ERROR);


### PR DESCRIPTION
I did not implement detection of missing `aligned_alloc` or where to set `USE_POSIX_MEMALIGN`.

I am averse to CMake so it's probably better if you do this anyways.

Signed-off-by: Hammond, Jeff R <jeff.r.hammond@intel.com>