### PR TITLE
Add headers to fix icc compilation errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,8 +75,8 @@ IF ("${CMAKE_C_COMPILER_ID}" STREQUAL "Cray")
 ENDIF ()
 
 IF ("${CMAKE_C_COMPILER_ID}" STREQUAL "Intel") 
-    SET (OpenMP_C_FLAGS "${OpenMP_C_FLAGS} -xHost")
-    SET (OpenMP_C_FLAGS "${OpenMP_CXX_FLAGS} -xHost")
+    SET (OpenMP_C_FLAGS "${OpenMP_C_FLAGS} -xHost -qopenmp")
+    SET (OpenMP_C_FLAGS "${OpenMP_CXX_FLAGS} -xHost -qopenmp")
 ENDIF ()
 
  
@@ -147,6 +147,8 @@ IF (USE_OPENMP)
         FILE (GLOB BACKEND_C_FILES_OMP src/openmp/*.c)
         FILE (GLOB BACKEND_H_FILES_OMP src/openmp/*.h)
     ENDIF ()
+    SET (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+    SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 ENDIF ()
 
 # Enable CUDA

--- a/configure/configure_omp_intel
+++ b/configure/configure_omp_intel
@@ -10,7 +10,7 @@ COMPILER=intel
 BUILD_DIR=build_${BACKEND}_${COMPILER}
 
 mkdir -p ${BUILD_DIR} && cd ${BUILD_DIR}
-rm -rf CMake* 
+rm -rf CMake*
 
 CC=icc
 CXX=icpc
@@ -21,9 +21,12 @@ CXX=icpc
 #Cross-platform but with AVX (KNL, SKL and newer)
 #FLAGS="-O3 -xCOMMON-AVX512"
 #Non-AVX platforms
-FLAGS="-O3"
-#Return vectorization report
-FLAGS="${FLAGS} -qopt-report-phase=vec,loop -qopt-report=2"
+
+#Disable flag that reports on cpu dispatch
+FLAGS="-O3 -std=c99 -diag-disable=15009"
+
+#Uncomment to Return vectorization report
+#FLAGS="${FLAGS} -qopt-report-phase=vec,loop -qopt-report=2"
 
 #Make sure to use tabs rather than spaces for newline entries
 cmake -D CMAKE_BUILD_TYPE=Release \
@@ -33,5 +36,5 @@ cmake -D CMAKE_BUILD_TYPE=Release \
 	-D USE_OPENCL=0 \
 	-D USE_OPENMP=1 \
 	-D USE_CUDA=0 \
-	-D USE_SERIAL=1 \
+	-D USE_SERIAL=0 \
 	..

--- a/include/parse-args.h
+++ b/include/parse-args.h
@@ -15,6 +15,7 @@
 
 #include <sgtype.h>
 #include <stdint.h>
+#include <sys/types.h>
 
 /** @brief Supported benchmark backends
  */

--- a/include/sgtime.h
+++ b/include/sgtime.h
@@ -1,3 +1,5 @@
+#define _POSIX_C_SOURCE 199309L
+
 #ifndef SGTIME_H
 #define SGTIME_H
 

--- a/src/parse-args.c
+++ b/src/parse-args.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <strings.h>
 #include <time.h>
 #include <sys/stat.h>
 #include <sys/types.h>

--- a/src/trace-util.c
+++ b/src/trace-util.c
@@ -1,3 +1,4 @@
+#define  _POSIX_C_SOURCE 200809L
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>

--- a/src/trace-util.c
+++ b/src/trace-util.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <sys/types.h>
 #include "sp_alloc.h"
 #include "trace-util.h"
 


### PR DESCRIPTION
Some headers and a source define were needed for compilation with icc. 