### PR TITLE
Add Github Actions for build testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,15 @@
+name: Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: ./configure/configure_serial_gnu && make -C build_serial_gnu


### PR DESCRIPTION
Adds Github Action that makes `configure_serial_gnu` to make sure that new pull requests to the `master` branch do not break the code.

### Testing
- [x] On the forked repo