### PR TITLE
CUDA CMake updates: Needed for a few internal runs that Galen and I are doing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 # 3.10 is specified since this is the first version with FindCUDAToolkit support
 CMAKE_MINIMUM_REQUIRED (VERSION 3.10 FATAL_ERROR)
+project(spatter C CXX CUDA)
 
 SET (CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
@@ -32,7 +33,8 @@ ENDIF ()
 
 # Set CUDA compiler
 IF (USE_CUDA)
-    SET (CMAKE_CUDA_COMPILER /usr/local/cuda/bin/nvcc)
+    find_package(CUDAToolkit)
+    #SET (CMAKE_CUDA_COMPILER /usr/local/cuda/bin/nvcc)
     SET (CMAKE_CUDA_COMPILER_ENV_VAR "CUDAC")
 ENDIF ()
 
@@ -243,12 +245,12 @@ TARGET_LINK_LIBRARIES(${TRGT} LINK_PUBLIC argtable3_static)
 TARGET_LINK_LIBRARIES (${TRGT} LINK_PUBLIC m)
 
 IF (USE_CUDA)
-    FIND_LIBRARY (
-        CUDART_LIBRARY cudart
-        HINTS
-            /usr/local/cuda/targets/x86_64-linux/lib/ /usr/local/cuda/lib64/
-    )
-    TARGET_LINK_LIBRARIES (${TRGT} LINK_PUBLIC ${CUDART_LIBRARY})
+    #FIND_LIBRARY (
+    #    CUDART_LIBRARY cudart
+    #    HINTS
+    #        /usr/local/cuda/targets/x86_64-linux/lib/ /usr/local/cuda/lib64/
+    #)
+    TARGET_LINK_LIBRARIES (${TRGT} LINK_PUBLIC CUDA::cudart)
 ENDIF ()
 
 #Include PAPI libraries, if defined

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # 3.10 is specified since this is the first version with FindCUDAToolkit support
 CMAKE_MINIMUM_REQUIRED (VERSION 3.10 FATAL_ERROR)
-project(spatter C CXX CUDA)
+project(spatter C CXX)
 
 SET (CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
@@ -33,6 +33,7 @@ ENDIF ()
 
 # Set CUDA compiler
 IF (USE_CUDA)
+    enable_language(CUDA)
     find_package(CUDAToolkit)
     #SET (CMAKE_CUDA_COMPILER /usr/local/cuda/bin/nvcc)
     SET (CMAKE_CUDA_COMPILER_ENV_VAR "CUDAC")

--- a/configure/configure_cuda
+++ b/configure/configure_cuda
@@ -6,6 +6,9 @@
 
 BUILD_DIR=build_cuda
 
+cc=$1
+echo "Building for compute capability ${cc}"
+
 mkdir -p ${BUILD_DIR} && cd ${BUILD_DIR}
 rm -rf CMake* 
 
@@ -13,7 +16,7 @@ rm -rf CMake*
 cmake -D CMAKE_BUILD_TYPE=Release \
 	-D CMAKE_CXX_COMPILER=nvcc \
 	-D CMAKE_CXX_FLAGS="-O3 " \
-	-D USE_CUDA=1 -D CUDA_FLAGS="-arch sm_70"\
+	-D USE_CUDA=1 -D CMAKE_CUDA_ARCHITECTURES=${cc}\
 	-D USE_OPENCL=0 \
 	-D USE_OPENMP=0 \
 	..    


### PR DESCRIPTION
CMake with `module load cuda` and ./configure/configure_cuda not easily configurable to set appropriate paths

CUDA CMake updates:
    - update to findpackage(CudaToolkit)
    - include_directories to include CUDA headers
    - target_link_libraries updated to `CUDA::cudart`
    - argument passed to `configure/configure_cuda` to specify the compute capability (changed to `CMAKE_CUDA_ARCHITECTURES`) to provide more flexibility

Am now able to easily build on A100 and H100 internally