### PR TITLE
Change workflow to run for main instead of master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build-and-run:


### PR DESCRIPTION
The tests don't run for the `main` branch because we didn't update the `build.yml` file. This fixes that.