### PR TITLE
Cast size_t nruns to int for comparison (Fixes time = 0 bug)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -623,7 +623,7 @@ int main(int argc, char **argv)
         int wpt = 1;
         if (backend == CUDA) {
             float time_ms = 2;
-            for (int i = -10; i < rc2[k].nruns; i++) {
+            for (int i = -10; i < (int) rc2[k].nruns; i++) {
 #define arr_len (1)
                 if (rc2[k].kernel == MULTISCATTER) {
                   unsigned long global_work_size = rc2[k].generic_len / wpt * rc2[k].pattern_scatter_len;
@@ -676,7 +676,7 @@ int main(int argc, char **argv)
             omp_set_num_threads(rc2[k].omp_threads);
 
             // Start at -1 to do a cache warm
-            for (int i = -1; i < rc2[k].nruns; i++) {
+            for (int i = -1; i < (int) rc2[k].nruns; i++) {
 
                 if (i!=-1) sg_zero_time();
 #ifdef USE_PAPI
@@ -764,7 +764,7 @@ int main(int argc, char **argv)
         #ifdef USE_SERIAL
         if (backend == SERIAL) {
 
-            for (int i = -1; i < rc2[k].nruns; i++) {
+            for (int i = -1; i < (int) rc2[k].nruns; i++) {
 
                 if (i!=-1) sg_zero_time();
 #ifdef USE_PAPI

--- a/src/main.c
+++ b/src/main.c
@@ -134,6 +134,9 @@ int compare (const void * a, const void * b)
 /** Time reported in seconds, sizes reported in bytes, bandwidth reported in mib/s"
  */
 double report_time(int ii, double time,  struct run_config rc, int idx){
+    if (time == 0.0) {
+        error("Time is zero", ERROR);
+    }
     size_t bytes_moved = 0;
     double actual_bandwidth = 0;
 


### PR DESCRIPTION
Comparison of negative `int` with unsigned `size_t` caused `time = 0` for all kernels. 

[Reference](https://stackoverflow.com/a/3642067/14837560)