### PR TITLE
Allow gcc to vectorize gather_smallbuf() in openmp_kernels

### DIFF
--- a/src/openmp/openmp_kernels.c
+++ b/src/openmp/openmp_kernels.c
@@ -301,6 +301,7 @@ void gather_smallbuf(
         size_t delta,
         size_t n,
         size_t target_len) {
+
 #ifdef __GNUC__
     #pragma omp parallel
 #else
@@ -311,19 +312,21 @@ void gather_smallbuf(
 
 #ifdef __CRAYC__
     #pragma concurrent
-#endif
-#ifdef __INTEL_COMPILER
+#elif defined __INTEL_COMPILER
     #pragma ivdep
 #endif
+
 #pragma omp for
         for (size_t i = 0; i < n; i++) {
            sgData_t *sl = source + delta * i;
            sgData_t *tl = target[t] + pat_len*(i%target_len);
+
 #ifdef __CRAYC__
     #pragma concurrent
-#endif
-#if defined __CRAYC__ || defined __INTEL_COMPILER
+#elif defined __CRAYC__ || defined __INTEL_COMPILER
     #pragma vector always,unaligned
+#elif defined __GNUC__
+    #pragma omp simd   // or: #pragma GCC ivdep
 #endif
            for (size_t j = 0; j < pat_len; j++) {
                tl[j] = sl[pat[j]];


### PR DESCRIPTION
These are trivial tweaks that only change omp `gather_smallbuf()` for gcc, because that's all I've tested.  I am currently making use of them by passing in some compile-time flags via CMAKE_C_FLAGS at build time.  For example, on a Sapphire-Rapids node, even with `-march=native`, gcc only uses AVX2 instructions.  To get it to use AVX512 vector instructions, you apparently need `-fprefer-vector-width=512`, and gcc >= 11.  I have some scripting to figure out the gcc options from our side, but integrating automated options directly into your CMakeLists.txt would require a-little-more-comprehensive testing across compilers and hosts.  The larger vectors do show some additional speedup (beyond AVX2) in a weak-scaling test.