### PR TITLE
Fix issues with CUDA testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Usage:
  -R, --runs=<n>               Number of times to repeat execution of the kernel. [Default: 10]
  -t, --omp-threads=<n>        Number of OpenMP threads. [Default: OMP_MAX_THREADS]
  -v, --vector-len=<n>         TODO
- -z, --local-work-size=<n>    Numer of Gathers or Scatters performed by each thread on a GPU.
+ -z, --local-work-size=<n>    Number of Gathers or Scatters performed by each thread on a GPU. [Default: 1024]
  -m, --shared-memory=<n>      Amount of dummy shared memory to allocate on GPUs (used for occupancy control).
  -n, --name=<name>            Specify and name this configuration in the output.
  -s, --random=[<n>]           Sets the seed, or uses a random one if no seed is specified.

--- a/src/cuda/my_kernel.cu
+++ b/src/cuda/my_kernel.cu
@@ -581,6 +581,12 @@ extern "C" float cuda_block_wrapper(uint dim, uint* grid, uint* block,
         double *final_gather_data,
         char validate)
 {
+
+    if (pat_len > 1024) {
+        printf("ERROR: Currently, a pattern length greater than 1024 is not supported\n");
+        exit(1);
+    }
+
     dim3 grid_dim, block_dim;
     cudaEvent_t start, stop;
 
@@ -620,6 +626,7 @@ extern "C" float cuda_block_wrapper(uint dim, uint* grid, uint* block,
                 gather_block_morton<4096><<<grid_dim, block_dim>>>(source, pat_dev, pat_len, delta, wpt, order_dev, validate);
             }else {
                 printf("ERROR NOT SUPPORTED: %zu\n", pat_len);
+                exit(1);
             }
 
         } else if (stride >= 0) {
@@ -647,6 +654,7 @@ extern "C" float cuda_block_wrapper(uint dim, uint* grid, uint* block,
                 gather_block_stride<4096><<<grid_dim, block_dim>>>(source, pat_dev, pat_len, delta, wpt, stride, validate);
             }else {
                 printf("ERROR NOT SUPPORTED: %zu\n", pat_len);
+                exit(1);
             }
 
         } else {
@@ -674,6 +682,7 @@ extern "C" float cuda_block_wrapper(uint dim, uint* grid, uint* block,
                 gather_block<4096><<<grid_dim, block_dim>>>(source, pat_dev, pat_len, delta, wpt, validate);
             }else {
                 printf("ERROR NOT SUPPORTED: %zu\n", pat_len);
+                exit(1);
             }
         }
         cudaMemcpyFromSymbol(final_gather_data, final_gather_data_dev, sizeof(double), 0, cudaMemcpyDeviceToHost);
@@ -700,6 +709,7 @@ extern "C" float cuda_block_wrapper(uint dim, uint* grid, uint* block,
             scatter_block<4096><<<grid_dim, block_dim>>>(source, pat_dev, pat_len, delta, wpt, validate);
         }else {
             printf("ERROR NOT SUPPORTED, %zu\n", pat_len);
+            exit(1);
         }
 
     }
@@ -729,6 +739,11 @@ extern "C" float cuda_block_random_wrapper(uint dim, uint* grid, uint* block,
         size_t wrap,
         int wpt, size_t seed)
 {
+    if (pat_len > 1024) {
+        printf("ERROR: Currently, a pattern length greater than 1024 is not supported\n");
+        exit(1);
+    }
+
     dim3 grid_dim, block_dim;
     cudaEvent_t start, stop;
 
@@ -813,6 +828,11 @@ extern "C" float cuda_new_wrapper(uint dim, uint* grid, uint* block,
         size_t wrap,
         int wpt)
 {
+    if (pat_len > 1024) {
+        printf("ERROR: Currently, a pattern length greater than 1024 is not supported\n");
+        exit(1);
+    }
+
     dim3 grid_dim, block_dim;
     cudaEvent_t start, stop;
 
@@ -1020,6 +1040,11 @@ extern "C" float cuda_block_sg_wrapper(uint dim, uint* grid, uint* block,
         double *final_gather_data,
         char validate)
 {
+    if (rc->pattern_gather_len > 1024 || rc->pattern_scatter_len > 1024 ) {
+        printf("ERROR: Currently, a pattern length greater than 1024 is not supported\n");
+        exit(1);
+    }
+
     dim3 grid_dim, block_dim;
     cudaEvent_t start, stop;
 
@@ -1150,6 +1175,11 @@ extern "C" float cuda_block_multiscatter_wrapper(uint dim, uint* grid, uint* blo
         double *final_gather_data,
         char validate)
 {
+    if (rc->pattern_len > 1024 || rc->pattern_scatter_len > 1024) {
+        printf("ERROR: Currently, a pattern length greater than 1024 is not supported\n");
+        exit(1);
+    }
+
     dim3 grid_dim, block_dim;
     cudaEvent_t start, stop;
 
@@ -1278,6 +1308,11 @@ extern "C" float cuda_block_multigather_wrapper(uint dim, uint* grid, uint* bloc
         double *final_gather_data,
         char validate)
 {
+    if (rc->pattern_len > 1024 || rc->pattern_gather_len > 1024) {
+        printf("ERROR: Currently, a pattern length greater than 1024 is not supported\n");
+        exit(1);
+    }
+
     dim3 grid_dim, block_dim;
     cudaEvent_t start, stop;
 

--- a/src/cuda/my_kernel.cu
+++ b/src/cuda/my_kernel.cu
@@ -582,11 +582,6 @@ extern "C" float cuda_block_wrapper(uint dim, uint* grid, uint* block,
         char validate)
 {
 
-    if (pat_len > 1024) {
-        printf("ERROR: Currently, a pattern length greater than 1024 is not supported\n");
-        exit(1);
-    }
-
     dim3 grid_dim, block_dim;
     cudaEvent_t start, stop;
 
@@ -739,11 +734,6 @@ extern "C" float cuda_block_random_wrapper(uint dim, uint* grid, uint* block,
         size_t wrap,
         int wpt, size_t seed)
 {
-    if (pat_len > 1024) {
-        printf("ERROR: Currently, a pattern length greater than 1024 is not supported\n");
-        exit(1);
-    }
-
     dim3 grid_dim, block_dim;
     cudaEvent_t start, stop;
 
@@ -828,11 +818,6 @@ extern "C" float cuda_new_wrapper(uint dim, uint* grid, uint* block,
         size_t wrap,
         int wpt)
 {
-    if (pat_len > 1024) {
-        printf("ERROR: Currently, a pattern length greater than 1024 is not supported\n");
-        exit(1);
-    }
-
     dim3 grid_dim, block_dim;
     cudaEvent_t start, stop;
 
@@ -1040,11 +1025,6 @@ extern "C" float cuda_block_sg_wrapper(uint dim, uint* grid, uint* block,
         double *final_gather_data,
         char validate)
 {
-    if (rc->pattern_gather_len > 1024 || rc->pattern_scatter_len > 1024 ) {
-        printf("ERROR: Currently, a pattern length greater than 1024 is not supported\n");
-        exit(1);
-    }
-
     dim3 grid_dim, block_dim;
     cudaEvent_t start, stop;
 
@@ -1175,11 +1155,6 @@ extern "C" float cuda_block_multiscatter_wrapper(uint dim, uint* grid, uint* blo
         double *final_gather_data,
         char validate)
 {
-    if (rc->pattern_len > 1024 || rc->pattern_scatter_len > 1024) {
-        printf("ERROR: Currently, a pattern length greater than 1024 is not supported\n");
-        exit(1);
-    }
-
     dim3 grid_dim, block_dim;
     cudaEvent_t start, stop;
 
@@ -1308,11 +1283,6 @@ extern "C" float cuda_block_multigather_wrapper(uint dim, uint* grid, uint* bloc
         double *final_gather_data,
         char validate)
 {
-    if (rc->pattern_len > 1024 || rc->pattern_gather_len > 1024) {
-        printf("ERROR: Currently, a pattern length greater than 1024 is not supported\n");
-        exit(1);
-    }
-
     dim3 grid_dim, block_dim;
     cudaEvent_t start, stop;
 

--- a/src/main.c
+++ b/src/main.c
@@ -1161,6 +1161,5 @@ spIdx_t remap_pattern(const int nrc, ssize_t *pattern, const spSize_t pattern_le
         }
     }
 
-    printf("Pattern Length: %zu Max Pattern Value: %zu\n\n", pattern_len, max_pattern_val);
     return max_pattern_val;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -629,6 +629,17 @@ int main(int argc, char **argv)
             for (int i = -10; i < (int) rc2[k].nruns; i++) {
 #define arr_len (1)
                 if (rc2[k].kernel == MULTISCATTER) {
+                  if (rc2[k].pattern_scatter_len > rc2[k].local_work_size) {
+                      error("Pattern length cannot exceed local_work_size", ERROR);
+                  }
+                  if (rc2[k].pattern_scatter_len > 1024) {
+                      error("Pattern length cannot exceed 1024 on GPU", ERROR);
+                  }
+                    /*
+                  if (rc2[k].pattern_scatter_len > local_work_size) {
+                      error("Pattern length cannot exceed local_work_size", ERROR);
+                  }
+                  */
                   unsigned long global_work_size = rc2[k].generic_len / wpt * rc2[k].pattern_scatter_len;
                   unsigned long local_work_size = rc2[k].local_work_size;
                   unsigned long grid[arr_len] = {global_work_size/local_work_size};
@@ -637,6 +648,12 @@ int main(int argc, char **argv)
                   time_ms = cuda_block_multiscatter_wrapper(arr_len, grid, block, source.dev_ptr_cuda, target.dev_ptr_cuda, &rc2[k], pat_dev, pat_scat_dev, wpt, &final_block_idx, &final_thread_idx, &final_gather_data, validate_flag);
                 }
                 else if (rc2[k].kernel == MULTIGATHER) {
+                  if (rc2[k].pattern_gather_len > rc2[k].local_work_size) {
+                      error("Pattern length cannot exceed local_work_size", ERROR);
+                  }
+                  if (rc2[k].pattern_gather_len > 1024) {
+                      error("Pattern length cannot exceed 1024 on GPU", ERROR);
+                  }
                   unsigned long global_work_size = rc2[k].generic_len / wpt * rc2[k].pattern_gather_len;
                   unsigned long local_work_size = rc2[k].local_work_size;
                   unsigned long grid[arr_len] = {global_work_size/local_work_size};
@@ -645,6 +662,12 @@ int main(int argc, char **argv)
                   time_ms = cuda_block_multigather_wrapper(arr_len, grid, block, source.dev_ptr_cuda, target.dev_ptr_cuda, &rc2[k], pat_dev, pat_gath_dev, wpt, &final_block_idx, &final_thread_idx, &final_gather_data, validate_flag);
                 }
                 else if (rc2[k].kernel == GS) {
+                    if (rc2[k].pattern_gather_len > rc2[k].local_work_size) {
+                        error("Pattern length cannot exceed local_work_size", ERROR);
+                    }
+                    if (rc2[k].pattern_gather_len > 1024) {
+                        error("Pattern length cannot exceed 1024 on GPU", ERROR);
+                    }
                     unsigned long global_work_size = rc2[k].generic_len / wpt * rc2[k].pattern_gather_len;
                     unsigned long local_work_size = rc2[k].local_work_size;
                     unsigned long grid[arr_len]  = {global_work_size/local_work_size};
@@ -653,6 +676,12 @@ int main(int argc, char **argv)
                     assert(rc2[k].pattern_gather_len == rc2[k].pattern_scatter_len);
                     time_ms = cuda_block_sg_wrapper(arr_len, grid, block, source.dev_ptr_cuda, target.dev_ptr_cuda, &rc2[k], pat_gath_dev, pat_scat_dev, wpt, &final_block_idx, &final_thread_idx, &final_gather_data, validate_flag);
                 } else {
+                    if (rc2[k].pattern_len > rc2[k].local_work_size) {
+                        error("Pattern length cannot exceed local_work_size", ERROR);
+                    }
+                    if (rc2[k].pattern_len > 1024) {
+                        error("Pattern length cannot exceed 1024 on GPU", ERROR);
+                    }
                     unsigned long global_work_size = rc2[k].generic_len / wpt * rc2[k].pattern_len;
                     unsigned long local_work_size = rc2[k].local_work_size;
                     unsigned long grid[arr_len]  = {global_work_size/local_work_size};

--- a/src/main.c
+++ b/src/main.c
@@ -632,7 +632,7 @@ int main(int argc, char **argv)
                   if (rc2[k].pattern_scatter_len > rc2[k].local_work_size) {
                       error("Pattern length cannot exceed local_work_size", ERROR);
                   }
-                  if (rc2[k].pattern_scatter_len > 1024) {
+                  if (rc2[k].local_work_size > 1024) {
                       error("Pattern length cannot exceed 1024 on GPU", ERROR);
                   }
                     /*
@@ -651,7 +651,7 @@ int main(int argc, char **argv)
                   if (rc2[k].pattern_gather_len > rc2[k].local_work_size) {
                       error("Pattern length cannot exceed local_work_size", ERROR);
                   }
-                  if (rc2[k].pattern_gather_len > 1024) {
+                  if (rc2[k].local_work_size > 1024) {
                       error("Pattern length cannot exceed 1024 on GPU", ERROR);
                   }
                   unsigned long global_work_size = rc2[k].generic_len / wpt * rc2[k].pattern_gather_len;
@@ -665,7 +665,7 @@ int main(int argc, char **argv)
                     if (rc2[k].pattern_gather_len > rc2[k].local_work_size) {
                         error("Pattern length cannot exceed local_work_size", ERROR);
                     }
-                    if (rc2[k].pattern_gather_len > 1024) {
+                    if (rc2[k].local_work_size > 1024) {
                         error("Pattern length cannot exceed 1024 on GPU", ERROR);
                     }
                     unsigned long global_work_size = rc2[k].generic_len / wpt * rc2[k].pattern_gather_len;
@@ -679,7 +679,7 @@ int main(int argc, char **argv)
                     if (rc2[k].pattern_len > rc2[k].local_work_size) {
                         error("Pattern length cannot exceed local_work_size", ERROR);
                     }
-                    if (rc2[k].pattern_len > 1024) {
+                    if (rc2[k].local_work_size > 1024) {
                         error("Pattern length cannot exceed 1024 on GPU", ERROR);
                     }
                     unsigned long global_work_size = rc2[k].generic_len / wpt * rc2[k].pattern_len;

--- a/src/parse-args.c
+++ b/src/parse-args.c
@@ -749,8 +749,8 @@ struct run_config *parse_runs(int argc, char **argv)
 #if defined USE_CUDA || defined USE_OPENCL
     if (rc->local_work_size == 0)
     {
-        error ("Local_work_size not set. Default is 1", WARN);
-        rc->local_work_size = 1;
+        error ("Local_work_size not set. Default is 1024", WARN);
+        rc->local_work_size = 1024;
     }
 #endif
     return rc;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,15 +17,14 @@ set( TESTAPPS #list apps
         parse_size
         standard_uniform_suite
         standard_ms1_suite
-        standard_laplacian_suite
         concurrent
         multilevel
     )
 
-IF(USE_CUDA)
+IF("${BACKEND}" STREQUAL "cuda")
     set(TESTAPPS  ${TESTAPPS} standard_suite_gpu)
 ELSE()
-    set(TESTAPPS  ${TESTAPPS} standard_suite_cpu)
+    set(TESTAPPS  ${TESTAPPS} standard_suite_cpu standard_laplacian_suite)
 ENDIF()
 
 file(GLOB src
@@ -53,7 +52,7 @@ foreach( APP ${TESTAPPS} )
 )
 set_tests_properties("${APP}_build" PROPERTIES FIXTURES_SETUP "test_${APP}_fixture")
  target_link_libraries( "${APP}" PRIVATE m )
- IF (USE_OPENMP)
+ IF ("${BACKEND}" STREQUAL "openmp")
      TARGET_LINK_LIBRARIES (${APP} PRIVATE OpenMP::OpenMP_CXX)
  ENDIF()
  add_test( NAME "${APP}_test" COMMAND "${APP}" )

--- a/tests/multilevel.c
+++ b/tests/multilevel.c
@@ -5,23 +5,31 @@
 #include <stdlib.h>
 
 int uniform_multilevel_test() {
-    for (int i = 1; i <= 10; i++) {
+    int len1 = 8;
+    int len2 = 8;
+    for (int i = 1; i <= 8; i++) {
         char *command;
-        int ret = asprintf(&command, "../spatter -kMultiGather -pUNIFORM:%d:%d -gUNIFORM:%d:%d ", i * i, i, i, i);
+        int ret = asprintf(&command, "../spatter -kMultiGather -pUNIFORM:%d:%d -gUNIFORM:%d:%d ", len1, i, len2, 1);
         if (ret == -1 || system(command) != EXIT_SUCCESS) {
             printf("Test failure on %s", command);
             return EXIT_FAILURE;
         }
+        len1 *= 2;
+        //len2 = len2*(i % 2 == 0 ? 2 : 1);
         free(command);
     }
-    for (int i = 1; i <= 10; i++) {
+    len1 = 8;
+    len2 = 8;
+    for (int i = 1; i <= 8; i++) {
         char *command;
-        int ret = asprintf(&command, "../spatter -kMultiScatter -pUNIFORM:%d:%d -hUNIFORM:%d:%d ", i * i, i, i, i);
+        int ret = asprintf(&command, "../spatter -kMultiScatter -pUNIFORM:%d:%d -hUNIFORM:%d:%d ", len1, i, len2, 1);
         if (ret == -1 || system(command) != EXIT_SUCCESS) {
             printf("Test failure on %s", command);
             return EXIT_FAILURE;
         }
         free(command);
+        len1 *= 2;
+        //len2 = len2*(i % 2 == 0 ? 2 : 1);
     }
     return EXIT_SUCCESS;
 }

--- a/tests/standard_ms1_suite.c
+++ b/tests/standard_ms1_suite.c
@@ -5,15 +5,15 @@
 #include <stdlib.h>
 
 int ms1_test_1() {
-    int length = 4, locations = 2, gaps = 16;
-    for (int i = 0; i < 10; i++) {
+    int length = 8, locations = 2, gaps = 16;
+    for (int i = 0; i < 8; i++) {
         char *command;
         int ret = asprintf(&command, "../spatter -pMS1:%d:%d:%d", length, locations, gaps);
         if (ret == -1 || system(command) != EXIT_SUCCESS) {
             printf("Test failure on %s", command);
             return EXIT_FAILURE;
         }
-        length += 2;
+        length *= 2;
         locations += 1;
         gaps += 2;
         free(command);
@@ -22,15 +22,15 @@ int ms1_test_1() {
 }
 
 int ms1_test_2() {
-    int length = 4, length2 = 1, locations = 2, locations2 = 16;
-    for (int i = 0; i < 10; i++) {
+    int length = 8, length2 = 1, locations = 2, locations2 = 16;
+    for (int i = 0; i < 8; i++) {
         char *command;
         int ret = asprintf(&command, "../spatter -pMS1:%d:%d,%d:%d", length, length2, locations, locations2);
         if (ret == -1 || system(command) != EXIT_SUCCESS) {
             printf("Test failure on %s", command);
             return EXIT_FAILURE;
         }
-        length += 2;
+        length *= 2;
         length2 += 2;
         locations += 1;
         locations2 += 2;
@@ -40,15 +40,15 @@ int ms1_test_2() {
 }
 
 int ms1_test_3() {
-    int length = 4, length2 = 1, locations = 2, locations2 = 16, gaps = 11;
-    for (int i = 0; i < 10; i++) {
+    int length = 8, length2 = 1, locations = 2, locations2 = 16, gaps = 11;
+    for (int i = 0; i < 8; i++) {
         char *command;
         int ret = asprintf(&command, "../spatter -pMS1:%d:%d,%d:%d,%d", length, length2, locations, locations2, gaps);
         if (ret == -1 || system(command) != EXIT_SUCCESS) {
             printf("Test failure on %s", command);
             return EXIT_FAILURE;
         }
-        length += 2;
+        length *= 2;
         length2 += 2;
         locations += 1;
         locations2 += 2;

--- a/tests/standard_uniform_suite.c
+++ b/tests/standard_uniform_suite.c
@@ -5,15 +5,15 @@
 #include <stdlib.h>
 
 int uniform_test_length_gap() {
-    int length = 4, gap = 2;
-    for (int i = 0; i < 10; i++) {
+    int length = 8, gap = 2;
+    for (int i = 0; i < 8; i++) {
         char *command;
         int ret = asprintf(&command, "../spatter -pUNIFORM:%d:%d", length, gap);
         if (ret == -1 || system(command) != EXIT_SUCCESS) {
             printf("Test failure on %s", command);
             return EXIT_FAILURE;
         }
-        length += 2;
+        length *= 2;
         gap += 2;
         free(command);
     }


### PR DESCRIPTION
Changes:
- Remove some extra output
- Stop users from running patterns larger than 1024 on GPU (this constraint should be removed in the future)
- Some GPU tests would fail silently. This has been fixed
- GPU tests which were failing silently because of bad pattern lengths have been updated.

Persisting issues:
- GPUs only support power of 2 pattern sizes between 8 and 1024. The Laplacian test has an irregular size and should not be run on GPU. (Test 28)
- When using the CUDA backend, we should run `standard_suite_gpu` instead of `standard_suite_cpu`. (Test 34)

@agustin-vaca Could you take a look at these two issues and push an update to this PR if you're able to solve them?
@JDTruj2018 Could you run this and see if it works ok with your GPU tests? 