### PR TITLE
Fix illegal UTF-8 characters in output

### DIFF
--- a/src/parse-args.c
+++ b/src/parse-args.c
@@ -748,7 +748,7 @@ struct run_config *parse_runs(int argc, char **argv)
     if (!strcasecmp(rc->name, "NONE"))
     {
         if (rc->type != CUSTOM)
-            safestrcopy(rc->name, rc->generator);
+            safestrcopy(rc->name, pattern->sval[0]);
         else
             safestrcopy(rc->name, "CUSTOM");
     }


### PR DESCRIPTION
Fixes issue where illegal UTF-8 characters were appearing in the run configuration section of Spatter output.