### PR TITLE
Remove unnecessary bounds checks in cuda kernels

### DIFF
--- a/src/cuda/my_kernel.cu
+++ b/src/cuda/my_kernel.cu
@@ -271,7 +271,7 @@ __global__ void cuda_scatter_atomic(const ssize_t* pattern, double *sparse, doub
     }
     #endif
 
-    if (j < pattern_length && i < count)
+    if (i < count)
         atomicExch((unsigned long long int*)&sparse[pattern[j] + delta * i], __double_as_longlong(dense[j + pattern_length * (i % wrap)]));
 }
 
@@ -287,7 +287,7 @@ __global__ void cuda_scatter(const ssize_t* pattern, double *sparse, double *den
     }
     #endif
 
-    if (j < pattern_length && i < count)
+    if (i < count)
         sparse[pattern[j] + delta * i] = dense[j + pattern_length * (i % wrap)];
 }
 
@@ -372,7 +372,7 @@ __global__ void cuda_gather(const ssize_t* pattern, const double *sparse, double
 
     double x;
 
-    if (j < pattern_length) {
+    if (i < count) {
         // dense[j + pattern_length * (i % wrap)] = sparse[pattern[j] + delta * i]; // configuration 1
         x = sparse[pattern[j] + delta * i]; // configuration 2
         if (x == 0.5)
@@ -1040,7 +1040,7 @@ __global__ void cuda_scatter_gather_atomic(const size_t *pattern_scatter,
     #endif
 
     // printf("%lu, %lu, %lu\n", total_id, j, i);
-    if (j < pattern_length && i < count)
+    if (i < count)
           atomicExch((unsigned long long int*)&sparse_scatter[pattern_scatter[j] + delta_scatter * i], __double_as_longlong(sparse_gather[pattern_gather[j] + delta_gather * i]));
 }
 
@@ -1061,7 +1061,7 @@ __global__ void cuda_scatter_gather(const size_t *pattern_scatter,
     #endif
 
     // printf("%lu, %lu, %lu\n", total_id, j, i);
-    if (j < pattern_length && i < count)
+    if (i < count)
         sparse_scatter[pattern_scatter[j] + delta_scatter * i] = sparse_gather[pattern_gather[j] + delta_gather * i];
 }
 
@@ -1227,7 +1227,7 @@ __global__ void cuda_multi_scatter_atomic(const size_t *pattern,
     }
     #endif
 
-    if (j < pattern_length && i < count)
+    if (i < count)
         atomicExch((unsigned long long int*)&sparse[pattern[pattern_scatter[j]] + delta * i], __double_as_longlong(dense[j + pattern_length * (i % wrap)]));
 }
 __global__ void cuda_multi_scatter(const size_t *pattern,
@@ -1245,7 +1245,7 @@ __global__ void cuda_multi_scatter(const size_t *pattern,
     }
     #endif
 
-    if (j < pattern_length && i < count)
+    if (i < count)
         sparse[pattern[pattern_scatter[j]] + delta * i] = dense[j + pattern_length * (i % wrap)];
 }
 
@@ -1409,7 +1409,7 @@ __global__ void cuda_multi_gather(const size_t *pattern,
 
     double x;
 
-    if (j < pattern_length && i < count) {
+    if (i < count) {
         // dense[j + pattern_length * (i % wrap)] =
         // sparse[pattern[pattern_gather[j]] + delta * i];
         x = sparse[pattern[pattern_gather[j]] + delta * i];


### PR DESCRIPTION
Unnecessary checks on (j < pattern_length) in the CUDA kernels, since j is calculated from `j = total_id % pattern_length`.

The only check necessary in all CUDA kernels is `if (i < count)` since `i = total_id / pattern_length` can be larger than `count`.