### PR TITLE
Fix divide by 0 bug when source.len is < 64

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -541,6 +541,10 @@ int main(int argc, char **argv)
     target.host_ptr = target.host_ptrs[0];
     //    printf("-- here -- \n");
 
+    if (source.len < 64) {
+        source.len = 64;
+    }
+
     // Populate buffers on host
     #pragma omp parallel for
     for (size_t i = 0; i < source.len; i++) {


### PR DESCRIPTION
Was running in to a divide by 0 error when running a few of the Quicksilver patterns when source.len is less than 64