### PR TITLE
Fix Issues with CUDA Backend

### DIFF
--- a/src/Spatter/Configuration.cc
+++ b/src/Spatter/Configuration.cc
@@ -13,26 +13,30 @@ ConfigurationBase::ConfigurationBase(const size_t id, const std::string name,
     std::string k, const aligned_vector<size_t> &pattern,
     const aligned_vector<size_t> &pattern_gather,
     const aligned_vector<size_t> &pattern_scatter,
-    aligned_vector<double> &sparse, size_t &sparse_size,
-    aligned_vector<double> &sparse_gather, size_t &sparse_gather_size,
-    aligned_vector<double> &sparse_scatter, size_t &sparse_scatter_size,
-    aligned_vector<double> &dense, size_t &dense_size,
-    aligned_vector<aligned_vector<double>> &dense_perthread, const size_t delta,
-    const size_t delta_gather, const size_t delta_scatter, const long int seed,
-    const size_t wrap, const size_t count, const size_t shared_mem,
-    const size_t local_work_size, const int nthreads, const unsigned long nruns,
-    const bool aggregate, const bool atomic, const unsigned long verbosity)
+    aligned_vector<double> &sparse, double *&dev_sparse, size_t &sparse_size,
+    aligned_vector<double> &sparse_gather, double *&dev_sparse_gather,
+    size_t &sparse_gather_size, aligned_vector<double> &sparse_scatter,
+    double *&dev_sparse_scatter, size_t &sparse_scatter_size,
+    aligned_vector<double> &dense,
+    aligned_vector<aligned_vector<double>> &dense_perthread, double *&dev_dense,
+    size_t &dense_size, const size_t delta, const size_t delta_gather,
+    const size_t delta_scatter, const long int seed, const size_t wrap,
+    const size_t count, const size_t shared_mem, const size_t local_work_size,
+    const int nthreads, const unsigned long nruns, const bool aggregate,
+    const bool atomic, const unsigned long verbosity)
     : id(id), name(name), kernel(k), pattern(pattern),
       pattern_gather(pattern_gather), pattern_scatter(pattern_scatter),
-      sparse(sparse), sparse_size(sparse_size), sparse_gather(sparse_gather),
+      sparse(sparse), dev_sparse(dev_sparse), sparse_size(sparse_size),
+      sparse_gather(sparse_gather), dev_sparse_gather(dev_sparse_gather),
       sparse_gather_size(sparse_gather_size), sparse_scatter(sparse_scatter),
+      dev_sparse_scatter(dev_sparse_scatter),
       sparse_scatter_size(sparse_scatter_size), dense(dense),
-      dense_size(dense_size), dense_perthread(dense_perthread), delta(delta),
-      delta_gather(delta_gather), delta_scatter(delta_scatter), seed(seed),
-      wrap(wrap), count(count), shmem(shared_mem),
-      local_work_size(local_work_size), omp_threads(nthreads), nruns(nruns),
-      aggregate(aggregate), atomic(atomic), verbosity(verbosity),
-      time_seconds(nruns, 0) {
+      dense_perthread(dense_perthread), dev_dense(dev_dense),
+      dense_size(dense_size), delta(delta), delta_gather(delta_gather),
+      delta_scatter(delta_scatter), seed(seed), wrap(wrap), count(count),
+      shmem(shared_mem), local_work_size(local_work_size),
+      omp_threads(nthreads), nruns(nruns), aggregate(aggregate), atomic(atomic),
+      verbosity(verbosity), time_seconds(nruns, 0) {
   std::transform(kernel.begin(), kernel.end(), kernel.begin(),
       [](unsigned char c) { return std::tolower(c); });
 }
@@ -387,19 +391,23 @@ Configuration<Spatter::Serial>::Configuration(const size_t id,
     const aligned_vector<size_t> &pattern,
     const aligned_vector<size_t> &pattern_gather,
     const aligned_vector<size_t> &pattern_scatter,
-    aligned_vector<double> &sparse, size_t &sparse_size,
-    aligned_vector<double> &sparse_gather, size_t &sparse_gather_size,
-    aligned_vector<double> &sparse_scatter, size_t &sparse_scatter_size,
-    aligned_vector<double> &dense, size_t &dense_size,
-    aligned_vector<aligned_vector<double>> &dense_perthread, const size_t delta,
+    aligned_vector<double> &sparse, double *&dev_sparse, size_t &sparse_size,
+    aligned_vector<double> &sparse_gather, double *&dev_sparse_gather,
+    size_t &sparse_gather_size, aligned_vector<double> &sparse_scatter,
+    double *&dev_sparse_scatter, size_t &sparse_scatter_size,
+    aligned_vector<double> &dense,
+    aligned_vector<aligned_vector<double>> &dense_perthread,
+    double *&dev_dense, size_t &dense_size,const size_t delta,
     const size_t delta_gather, const size_t delta_scatter, const long int seed,
     const size_t wrap, const size_t count, const unsigned long nruns,
     const bool aggregate, const unsigned long verbosity)
     : ConfigurationBase(id, name, kernel, pattern, pattern_gather,
-          pattern_scatter, sparse, sparse_size, sparse_gather,
-          sparse_gather_size, sparse_scatter, sparse_scatter_size, dense,
-          dense_size, dense_perthread, delta, delta_gather, delta_scatter, seed,
-          wrap, count, 0, 1024, 1, nruns, aggregate, false, verbosity) {
+          pattern_scatter, sparse, dev_sparse, sparse_size, sparse_gather,
+          dev_sparse_gather, sparse_gather_size, sparse_scatter,
+          dev_sparse_scatter, sparse_scatter_size, dense, dense_perthread,
+          dev_dense, dense_size, delta, delta_gather,
+          delta_scatter, seed, wrap, count, 0, 1024, 1, nruns, aggregate, false,
+          verbosity) {
   ConfigurationBase::setup();
 }
 
@@ -521,20 +529,23 @@ Configuration<Spatter::OpenMP>::Configuration(const size_t id,
     const aligned_vector<size_t> &pattern,
     const aligned_vector<size_t> &pattern_gather,
     aligned_vector<size_t> &pattern_scatter,
-    aligned_vector<double> &sparse, size_t &sparse_size,
-    aligned_vector<double> &sparse_gather, size_t &sparse_gather_size,
-    aligned_vector<double> &sparse_scatter, size_t &sparse_scatter_size,
-    aligned_vector<double> &dense, size_t &dense_size,
-    aligned_vector<aligned_vector<double>> &dense_perthread, const size_t delta,
+    aligned_vector<double> &sparse, double *&dev_sparse, size_t &sparse_size,
+    aligned_vector<double> &sparse_gather, double *&dev_sparse_gather,
+    size_t &sparse_gather_size, aligned_vector<double> &sparse_scatter,
+    double *&dev_sparse_scatter, size_t &sparse_scatter_size,
+    aligned_vector<double> &dense,
+    aligned_vector<aligned_vector<double>> &dense_perthread,
+    double *&dev_dense, size_t &dense_size,const size_t delta,
     const size_t delta_gather, const size_t delta_scatter, const long int seed,
     const size_t wrap, const size_t count, const int nthreads,
     const unsigned long nruns, const bool aggregate, const bool atomic,
     const unsigned long verbosity)
     : ConfigurationBase(id, name, kernel, pattern, pattern_gather,
-          pattern_scatter, sparse, sparse_size, sparse_gather,
-          sparse_gather_size, sparse_scatter, sparse_scatter_size, dense,
-          dense_size, dense_perthread, delta, delta_gather, delta_scatter, seed,
-          wrap, count, 0, 1024, nthreads, nruns, aggregate, atomic, verbosity) {
+          pattern_scatter, sparse, dev_sparse, sparse_size, sparse_gather,
+          dev_sparse_gather, sparse_gather_size, sparse_scatter,
+          dev_sparse_scatter, sparse_scatter_size, dense, dense_perthread,
+          dev_dense, dense_size, delta, delta_gather, delta_scatter, seed, wrap,
+          count, 0, 1024, nthreads, nruns, aggregate, atomic, verbosity) {
   ConfigurationBase::setup();
 }
 
@@ -710,21 +721,25 @@ Configuration<Spatter::CUDA>::Configuration(const size_t id,
     const aligned_vector<size_t> &pattern,
     const aligned_vector<size_t> &pattern_gather,
     const aligned_vector<size_t> &pattern_scatter,
-    aligned_vector<double> &sparse, size_t &sparse_size,
-    aligned_vector<double> &sparse_gather, size_t &sparse_gather_size,
-    aligned_vector<double> &sparse_scatter, size_t &sparse_scatter_size,
-    aligned_vector<double> &dense, size_t &dense_size,
-    aligned_vector<aligned_vector<double>> &dense_perthread, const size_t delta,
-    const size_t delta_gather, const size_t delta_scatter, const long int seed,
-    const size_t wrap, const size_t count, const size_t shared_mem,
-    const size_t local_work_size, const unsigned long nruns,
-    const bool aggregate, const bool atomic, const unsigned long verbosity)
+    aligned_vector<double> &sparse, double *&dev_sparse, size_t &sparse_size,
+    aligned_vector<double> &sparse_gather, double *&dev_sparse_gather,
+    size_t &sparse_gather_size, aligned_vector<double> &sparse_scatter,
+    double *&dev_sparse_scatter, size_t &sparse_scatter_size,
+    aligned_vector<double> &dense,
+    aligned_vector<aligned_vector<double>> &dense_perthread, double *&dev_dense,
+    size_t &dense_size, const size_t delta, const size_t delta_gather,
+    const size_t delta_scatter, const long int seed, const size_t wrap,
+    const size_t count, const size_t shared_mem, const size_t local_work_size,
+    const unsigned long nruns, const bool aggregate, const bool atomic,
+    const unsigned long verbosity)
     : ConfigurationBase(id, name, kernel, pattern, pattern_gather,
-          pattern_scatter, sparse, sparse_size, sparse_gather,
-          sparse_gather_size, sparse_scatter, sparse_scatter_size, dense,
-          dense_size, dense_perthread, delta, delta_gather, delta_scatter, seed,
+          pattern_scatter, sparse, dev_sparse, sparse_size, sparse_gather,
+          dev_sparse_gather, sparse_gather_size, sparse_scatter,
+          dev_sparse_scatter, sparse_scatter_size, dense, dense_perthread,
+          dev_dense, dense_size, delta, delta_gather, delta_scatter, seed,
           wrap, count, shared_mem, local_work_size, 1, nruns, aggregate, atomic,
           verbosity) {
+  
   setup();
 }
 
@@ -733,11 +748,11 @@ Configuration<Spatter::CUDA>::~Configuration() {
   checkCudaErrors(cudaFree(dev_pattern_gather));
   checkCudaErrors(cudaFree(dev_pattern_scatter));
 
-  checkCudaErrors(cudaFree(dev_sparse));
-  checkCudaErrors(cudaFree(dev_sparse_gather));
-  checkCudaErrors(cudaFree(dev_sparse_scatter));
+  // checkCudaErrors(cudaFree(dev_sparse));
+  // checkCudaErrors(cudaFree(dev_sparse_gather));
+  // checkCudaErrors(cudaFree(dev_sparse_scatter));
 
-  checkCudaErrors(cudaFree(dev_dense));
+  // checkCudaErrors(cudaFree(dev_dense));
 }
 
 int Configuration<Spatter::CUDA>::run(bool timed, unsigned long run_id) {
@@ -852,34 +867,6 @@ void Configuration<Spatter::CUDA>::multi_scatter(
 void Configuration<Spatter::CUDA>::setup() {
   ConfigurationBase::setup();
 
-  if (sparse.size() < sparse_size) {
-    sparse.resize(sparse_size);
-
-    for (size_t i = 0; i < sparse.size(); ++i)
-      sparse[i] = rand();
-  }
-
-  if (sparse_gather.size() < sparse_gather_size) {
-    sparse_gather.resize(sparse_gather_size);
-
-    for (size_t i = 0; i < sparse_gather.size(); ++i)
-      sparse_gather[i] = rand();
-  }
-
-  if (sparse_scatter.size() < sparse_scatter_size) {
-    sparse_scatter.resize(sparse_scatter_size);
-
-    for (size_t i = 0; i < sparse_scatter.size(); ++i)
-      sparse_scatter[i] = rand();
-  }
-
-  if (dense.size() < dense_size) {
-    dense.resize(dense_size);
-
-    for (size_t i = 0; i < dense.size(); ++i)
-      dense[i] = rand();
-  }
-
   checkCudaErrors(
       cudaMalloc((void **)&dev_pattern, sizeof(size_t) * pattern.size()));
   checkCudaErrors(cudaMalloc(
@@ -887,30 +874,12 @@ void Configuration<Spatter::CUDA>::setup() {
   checkCudaErrors(cudaMalloc(
       (void **)&dev_pattern_scatter, sizeof(size_t) * pattern_scatter.size()));
 
-  checkCudaErrors(
-      cudaMalloc((void **)&dev_sparse, sizeof(double) * sparse.size()));
-  checkCudaErrors(cudaMalloc(
-      (void **)&dev_sparse_gather, sizeof(double) * sparse_gather.size()));
-  checkCudaErrors(cudaMalloc(
-      (void **)&dev_sparse_scatter, sizeof(double) * sparse_scatter.size()));
-  checkCudaErrors(
-      cudaMalloc((void **)&dev_dense, sizeof(double) * dense.size()));
-
   checkCudaErrors(cudaMemcpy(dev_pattern, pattern.data(),
       sizeof(size_t) * pattern.size(), cudaMemcpyHostToDevice));
   checkCudaErrors(cudaMemcpy(dev_pattern_gather, pattern_gather.data(),
       sizeof(size_t) * pattern_gather.size(), cudaMemcpyHostToDevice));
   checkCudaErrors(cudaMemcpy(dev_pattern_scatter, pattern_scatter.data(),
       sizeof(size_t) * pattern_scatter.size(), cudaMemcpyHostToDevice));
-
-  checkCudaErrors(cudaMemcpy(dev_sparse, sparse.data(),
-      sizeof(double) * sparse.size(), cudaMemcpyHostToDevice));
-  checkCudaErrors(cudaMemcpy(dev_sparse_gather, sparse_gather.data(),
-      sizeof(double) * sparse_gather.size(), cudaMemcpyHostToDevice));
-  checkCudaErrors(cudaMemcpy(dev_sparse_scatter, sparse_scatter.data(),
-      sizeof(double) * sparse_scatter.size(), cudaMemcpyHostToDevice));
-  checkCudaErrors(cudaMemcpy(dev_dense, dense.data(),
-      sizeof(double) * dense.size(), cudaMemcpyHostToDevice));
 
   checkCudaErrors(cudaDeviceSynchronize());
 }

--- a/src/Spatter/Configuration.hh
+++ b/src/Spatter/Configuration.hh
@@ -58,12 +58,14 @@ public:
       const aligned_vector<size_t> &pattern,
       const aligned_vector<size_t> &pattern_gather,
       const aligned_vector<size_t> &pattern_scatter,
-      aligned_vector<double> &sparse, size_t &sparse_size,
-      aligned_vector<double> &sparse_gather, size_t &sparse_gather_size,
-      aligned_vector<double> &sparse_scatter, size_t &sparse_scatter_size,
-      aligned_vector<double> &dense, size_t &dense_size,
+      aligned_vector<double> &sparse, double *&dev_sparse, size_t &sparse_size,
+      aligned_vector<double> &sparse_gather, double *&dev_sparse_gather,
+      size_t &sparse_gather_size, aligned_vector<double> &sparse_scatter,
+      double *&dev_sparse_scatter, size_t &sparse_scatter_size,
+      aligned_vector<double> &dense,
       aligned_vector<aligned_vector<double>> &dense_perthread,
-      const size_t delta, const size_t delta_gather, const size_t delta_scatter,
+      double *&dev_dense, size_t &dense_size, const size_t delta,
+      const size_t delta_gather, const size_t delta_scatter,
       const long int seed, const size_t wrap, const size_t count,
       const size_t shared_mem, const size_t local_work_size, const int nthreads,
       const unsigned long nruns, const bool aggregate, const bool atomic,
@@ -103,15 +105,21 @@ public:
   const aligned_vector<size_t> pattern_scatter;
 
   aligned_vector<double> &sparse;
+  double *&dev_sparse;
   size_t &sparse_size;
+
   aligned_vector<double> &sparse_gather;
+  double *&dev_sparse_gather;
   size_t &sparse_gather_size;
+
   aligned_vector<double> &sparse_scatter;
+  double *&dev_sparse_scatter;
   size_t &sparse_scatter_size;
 
   aligned_vector<double> &dense;
-  size_t &dense_size;
   aligned_vector<aligned_vector<double>> &dense_perthread;
+  double *&dev_dense;
+  size_t &dense_size;
 
   const size_t delta;
   const size_t delta_gather;
@@ -145,12 +153,14 @@ public:
       const std::string kernel, const aligned_vector<size_t> &pattern,
       const aligned_vector<size_t> &pattern_gather,
       const aligned_vector<size_t> &pattern_scatter,
-      aligned_vector<double> &sparse, size_t &sparse_size,
-      aligned_vector<double> &sparse_gather, size_t &sparse_gather_size,
-      aligned_vector<double> &sparse_scatter, size_t &sparse_scatter_size,
-      aligned_vector<double> &dense, size_t &dense_size,
+      aligned_vector<double> &sparse, double *&dev_sparse, size_t &sparse_size,
+      aligned_vector<double> &sparse_gather, double *&dev_sparse_gather,
+      size_t &sparse_gather_size, aligned_vector<double> &sparse_scatter,
+      double *&dev_sparse_scatter, size_t &sparse_scatter_size,
+      aligned_vector<double> &dense,
       aligned_vector<aligned_vector<double>> &dense_perthread,
-      const size_t delta, const size_t delta_gather, const size_t delta_scatter,
+      double *&dev_dense, size_t &dense_size, const size_t delta,
+      const size_t delta_gather, const size_t delta_scatter,
       const long int seed, const size_t wrap, const size_t count,
       const unsigned long nruns, const bool aggregate,
       const unsigned long verbosity);
@@ -169,12 +179,14 @@ public:
       const std::string kernel, const aligned_vector<size_t> &pattern,
       const aligned_vector<size_t> &pattern_gather,
       aligned_vector<size_t> &pattern_scatter,
-      aligned_vector<double> &sparse, size_t &sparse_size,
-      aligned_vector<double> &sparse_gather, size_t &sparse_gather_size,
-      aligned_vector<double> &sparse_scatter, size_t &sparse_scatter_size,
-      aligned_vector<double> &dense, size_t &dense_size,
+      aligned_vector<double> &sparse, double *&dev_sparse, size_t &sparse_size,
+      aligned_vector<double> &sparse_gather, double *&dev_sparse_gather,
+      size_t &sparse_gather_size, aligned_vector<double> &sparse_scatter,
+      double *&dev_sparse_scatter, size_t &sparse_scatter_size,
+      aligned_vector<double> &dense,
       aligned_vector<aligned_vector<double>> &dense_perthread,
-      const size_t delta, const size_t delta_gather, const size_t delta_scatter,
+      double *&dev_dense, size_t &dense_size, const size_t delta,
+      const size_t delta_gather, const size_t delta_scatter,
       const long int seed, const size_t wrap, const size_t count,
       const int nthreads, const unsigned long nruns, const bool aggregate,
       const bool atomic, const unsigned long verbosity);
@@ -196,12 +208,14 @@ public:
       const std::string kernel, const aligned_vector<size_t> &pattern,
       const aligned_vector<size_t> &pattern_gather,
       const aligned_vector<size_t> &pattern_scatter,
-      aligned_vector<double> &sparse, size_t &sparse_size,
-      aligned_vector<double> &sparse_gather, size_t &sparse_gather_size,
-      aligned_vector<double> &sparse_scatter, size_t &sparse_scatter_size,
-      aligned_vector<double> &dense, size_t &dense_size,
+      aligned_vector<double> &sparse, double *&dev_sparse, size_t &sparse_size,
+      aligned_vector<double> &sparse_gather, double *&dev_sparse_gather,
+      size_t &sparse_gather_size, aligned_vector<double> &sparse_scatter,
+      double *&dev_sparse_scatter, size_t &sparse_scatter_size,
+      aligned_vector<double> &dense,
       aligned_vector<aligned_vector<double>> &dense_perthread,
-      const size_t delta, const size_t delta_gather, const size_t delta_scatter,
+      double *&dev_dense, size_t &dense_size, const size_t delta,
+      const size_t delta_gather, const size_t delta_scatter,
       const long int seed, const size_t wrap, const size_t count,
       const size_t shared_mem, const size_t local_work_size,
       const unsigned long nruns, const bool aggregate, const bool atomic,
@@ -221,12 +235,6 @@ public:
   size_t *dev_pattern;
   size_t *dev_pattern_gather;
   size_t *dev_pattern_scatter;
-
-  double *dev_sparse;
-  double *dev_sparse_gather;
-  double *dev_sparse_scatter;
-
-  double *dev_dense;
 };
 #endif
 

--- a/src/Spatter/Input.hh
+++ b/src/Spatter/Input.hh
@@ -57,15 +57,21 @@ struct ClArgs {
   std::vector<std::unique_ptr<Spatter::ConfigurationBase>> configs;
 
   aligned_vector<double> sparse;
+  double *dev_sparse;
   size_t sparse_size;
+
   aligned_vector<double> sparse_gather;
+  double *dev_sparse_gather;
   size_t sparse_gather_size;
+
   aligned_vector<double> sparse_scatter;
+  double *dev_sparse_scatter;
   size_t sparse_scatter_size;
 
   aligned_vector<double> dense;
-  size_t dense_size;
   aligned_vector<aligned_vector<double>> dense_perthread;
+  double *dev_dense;
+  size_t dense_size;
 
   std::string backend;
   bool aggregate;
@@ -604,28 +610,32 @@ int parse_input(const int argc, char **argv, ClArgs &cl) {
     if (backend.compare("serial") == 0)
       c = std::make_unique<Spatter::Configuration<Spatter::Serial>>(0,
           config_name, kernel, pattern, pattern_gather, pattern_scatter,
-          cl.sparse, cl.sparse_size, cl.sparse_gather, cl.sparse_gather_size,
-          cl.sparse_scatter, cl.sparse_scatter_size, cl.dense, cl.dense_size,
-          cl.dense_perthread, delta, delta_gather, delta_scatter, seed, wrap,
-          count, nruns, aggregate, verbosity);
+          cl.sparse, cl.dev_sparse, cl.sparse_size, cl.sparse_gather,
+          cl.dev_sparse_gather, cl.sparse_gather_size, cl.sparse_scatter,
+          cl.dev_sparse_scatter, cl.sparse_scatter_size, cl.dense,
+          cl.dense_perthread, cl.dev_dense, cl.dense_size, delta, delta_gather,
+          delta_scatter, seed, wrap, count, nruns, aggregate, verbosity);
 #ifdef USE_OPENMP
     else if (backend.compare("openmp") == 0)
       c = std::make_unique<Spatter::Configuration<Spatter::OpenMP>>(0,
           config_name, kernel, pattern, pattern_gather, pattern_scatter,
-          cl.sparse, cl.sparse_size, cl.sparse_gather, cl.sparse_gather_size,
-          cl.sparse_scatter, cl.sparse_scatter_size, cl.dense, cl.dense_size,
-          cl.dense_perthread, delta, delta_gather, delta_scatter, seed, wrap,
-          count, nthreads, nruns, aggregate, atomic, verbosity);
+          cl.sparse, cl.dev_sparse, cl.sparse_size, cl.sparse_gather,
+          cl.dev_sparse_gather, cl.sparse_gather_size, cl.sparse_scatter,
+          cl.dev_sparse_scatter, cl.sparse_scatter_size, cl.dense,
+          cl.dense_perthread, cl.dev_dense, cl.dense_size, delta, delta_gather,
+          delta_scatter, seed, wrap, count, nthreads, nruns, aggregate, atomic,
+          verbosity);
 #endif
 #ifdef USE_CUDA
     else if (backend.compare("cuda") == 0)
       c = std::make_unique<Spatter::Configuration<Spatter::CUDA>>(0,
           config_name, kernel, pattern, pattern_gather, pattern_scatter,
-          cl.sparse, cl.sparse_size, cl.sparse_gather, cl.sparse_gather_size,
-          cl.sparse_scatter, cl.sparse_scatter_size, cl.dense, cl.dense_size,
-          cl.dense_perthread, delta, delta_gather, delta_scatter, seed, wrap,
-          count, shared_mem, local_work_size, nruns, aggregate, atomic,
-          verbosity);
+          cl.sparse, cl.dev_sparse, cl.sparse_size, cl.sparse_gather,
+          cl.dev_sparse_gather, cl.sparse_gather_size, cl.sparse_scatter,
+          cl.dev_sparse_scatter, cl.sparse_scatter_size, cl.dense,
+          cl.dense_perthread, cl.dev_dense, cl.dense_size, delta, delta_gather,
+          delta_scatter, seed, wrap, count, shared_mem, local_work_size, nruns,
+          aggregate, atomic, verbosity);
 #endif
     else {
       std::cerr << "Invalid Backend " << backend << std::endl;
@@ -635,9 +645,10 @@ int parse_input(const int argc, char **argv, ClArgs &cl) {
     cl.configs.push_back(std::move(c));
   } else {
     Spatter::JSONParser json_file = Spatter::JSONParser(json_fname, cl.sparse,
-        cl.sparse_size, cl.sparse_gather, cl.sparse_gather_size,
-        cl.sparse_scatter, cl.sparse_scatter_size, cl.dense, cl.dense_size,
-        cl.dense_perthread, backend, aggregate, atomic, compress, shared_mem,
+        cl.dev_sparse, cl.sparse_size, cl.sparse_gather, cl.dev_sparse_gather,
+        cl.sparse_gather_size, cl.sparse_scatter, cl.dev_sparse_scatter,
+        cl.sparse_scatter_size, cl.dense, cl.dense_perthread, cl.dev_dense,
+        cl.dense_size, backend, aggregate, atomic, compress, shared_mem,
         nthreads, verbosity);
 
     for (size_t i = 0; i < json_file.size(); ++i) {
@@ -646,36 +657,36 @@ int parse_input(const int argc, char **argv, ClArgs &cl) {
     }
   }
 
-  if ((backend.compare("serial") == 0) || (backend.compare("openmp") == 0)) {
-    if (cl.sparse.size() < cl.sparse_size) {
-      cl.sparse.resize(cl.sparse_size);
+  if (cl.sparse.size() < cl.sparse_size) {
+    cl.sparse.resize(cl.sparse_size);
 
-      for (size_t i = 0; i < cl.sparse.size(); ++i)
-        cl.sparse[i] = rand();
-    }
+    for (size_t i = 0; i < cl.sparse.size(); ++i)
+      cl.sparse[i] = rand();
+  }
 
-    if (cl.sparse_gather.size() < cl.sparse_gather_size) {
-      cl.sparse_gather.resize(cl.sparse_gather_size);
+  if (cl.sparse_gather.size() < cl.sparse_gather_size) {
+    cl.sparse_gather.resize(cl.sparse_gather_size);
 
-      for (size_t i = 0; i < cl.sparse_gather.size(); ++i)
-        cl.sparse_gather[i] = rand();
-    }
+    for (size_t i = 0; i < cl.sparse_gather.size(); ++i)
+      cl.sparse_gather[i] = rand();
+  }
 
-    if (cl.sparse_scatter.size() < cl.sparse_scatter_size) {
-      cl.sparse_scatter.resize(cl.sparse_scatter_size);
+  if (cl.sparse_scatter.size() < cl.sparse_scatter_size) {
+    cl.sparse_scatter.resize(cl.sparse_scatter_size);
 
-      for (size_t i = 0; i < cl.sparse_scatter.size(); ++i)
-        cl.sparse_scatter[i] = rand();
-    }
+    for (size_t i = 0; i < cl.sparse_scatter.size(); ++i)
+      cl.sparse_scatter[i] = rand();
+  }
 
-    if (cl.dense.size() < cl.dense_size) {
-      cl.dense.resize(cl.dense_size);
+  if (cl.dense.size() < cl.dense_size) {
+    cl.dense.resize(cl.dense_size);
 
-      for (size_t i = 0; i < cl.dense.size(); ++i)
-        cl.dense[i] = rand();
-    }
+    for (size_t i = 0; i < cl.dense.size(); ++i)
+      cl.dense[i] = rand();
+  }
 
 #ifdef USE_OPENMP
+  if (backend.compare("openmp") == 0) {
     cl.dense_perthread.resize(nthreads);
 
     for (int j = 0; j < nthreads; ++j) {
@@ -684,8 +695,31 @@ int parse_input(const int argc, char **argv, ClArgs &cl) {
       for (size_t i = 0; i < cl.dense_perthread[j].size(); ++i)
         cl.dense_perthread[j][i] = rand();
     }
-#endif
   }
+#endif
+#ifdef USE_CUDA
+  if (backend.compare("cuda") == 0) {
+    checkCudaErrors(cudaMalloc((void **)&cl.dev_sparse,
+        sizeof(double) * cl.sparse.size()));
+    checkCudaErrors(cudaMalloc((void **)&cl.dev_sparse_gather,
+        sizeof(double) * cl.sparse_gather.size()));
+    checkCudaErrors(cudaMalloc((void **)&cl.dev_sparse_scatter,
+        sizeof(double) * cl.sparse_scatter.size()));
+    checkCudaErrors(cudaMalloc((void **)&cl.dev_dense,
+        sizeof(double) * cl.dense.size()));
+
+    checkCudaErrors(cudaMemcpy(cl.dev_sparse, cl.sparse.data(),
+        sizeof(double) * cl.sparse.size(), cudaMemcpyHostToDevice));
+    checkCudaErrors(cudaMemcpy(cl.dev_sparse_gather, cl.sparse_gather.data(),
+        sizeof(double) * cl.sparse_gather.size(), cudaMemcpyHostToDevice));
+    checkCudaErrors(cudaMemcpy(cl.dev_sparse_scatter, cl.sparse_scatter.data(),
+        sizeof(double) * cl.sparse_scatter.size(), cudaMemcpyHostToDevice));
+    checkCudaErrors(cudaMemcpy(cl.dev_dense, cl.dense.data(),
+        sizeof(double) * cl.dense.size(), cudaMemcpyHostToDevice));
+
+    checkCudaErrors(cudaDeviceSynchronize());
+  }
+#endif
 
   for (auto const &config : cl.configs) {
     if (config->aggregate != aggregate) {

--- a/src/Spatter/JSONParser.hh
+++ b/src/Spatter/JSONParser.hh
@@ -27,19 +27,22 @@ namespace Spatter {
 class JSONParser {
 public:
   JSONParser(std::string filename, aligned_vector<double> &sparse,
-      size_t &sparse_size, aligned_vector<double> &sparse_gather,
+      double *&dev_sparse, size_t &sparse_size,
+      aligned_vector<double> &sparse_gather, double *&dev_sparse_gather,
       size_t &sparse_gather_size, aligned_vector<double> &sparse_scatter,
-      size_t &sparse_scatter_size, aligned_vector<double> &dense,
-      size_t &dense_size,
+      double *&dev_sparse_scatter, size_t &sparse_scatter_size,
+      aligned_vector<double> &dense,
       aligned_vector<aligned_vector<double>> &dense_perthread,
-      const std::string backend, const bool aggregate, const bool atomic,
-      const bool compress, const size_t shared_mem, const int nthreads,
+      double *&dev_dense, size_t &dense_size, const std::string backend,
+      const bool aggregate, const bool atomic, const bool compress,
+      const size_t shared_mem, const int nthreads,
       const unsigned long verbosity, const std::string name = "",
       const std::string kernel = "gather", const size_t pattern_size = 0,
       const size_t delta = 8, const size_t delta_gather = 8,
       const size_t delta_scatter = 8, const size_t boundary = 0,
       const long int seed = -1, const size_t wrap = 1,
-      const size_t count = 1024, const size_t local_work_size = 1024, const unsigned long nruns = 10);
+      const size_t count = 1024, const size_t local_work_size = 1024,
+      const unsigned long nruns = 10);
 
   size_t size();
 
@@ -55,15 +58,21 @@ private:
   size_t size_;
 
   aligned_vector<double> &sparse;
+  double *&dev_sparse;
   size_t &sparse_size;
+
   aligned_vector<double> &sparse_gather;
+  double *&dev_sparse_gather;
   size_t &sparse_gather_size;
+
   aligned_vector<double> &sparse_scatter;
+  double *&dev_sparse_scatter;
   size_t &sparse_scatter_size;
 
   aligned_vector<double> &dense;
-  size_t &dense_size;
   aligned_vector<aligned_vector<double>> &dense_perthread;
+  double *&dev_dense;
+  size_t &dense_size;
 
   std::string backend_;
   const bool aggregate_;


### PR DESCRIPTION
## Overview

This PR resolves #201 by updating the `report` function and addresses an out-of-memory error by moving the device buffers from the `ConfigurationBase` class to the `ClArgs` struct.

## ✨ Change Description/Rationale

- Updated `report` function to remove unnecessary multiplication and subsequent division by `nruns`
  - Now it more closely aligns with the calculation of `bytes_moved` in Spatter v1.1
- Moved `dev_sparse`, `dev_sparse_gather`, `dev_sparse_scatter`, and `dev_dense` buffers to `ClArgs`
  - Reduces the memory usage of the CUDA backend when multiple configs are provided
- Closes https://github.com/hpcgarage/spatter/issues/201

## 👀 Reviewer Checklist
- [ ] All GitHub actions and runners have passed if applicable
- [ ] Commits are clean and relevant

## ✅ PR Checklist

- [x] Remove or update the template boilerplate text
- [x] Commits are relevant and combined where appropriate
- [x] Rebase off ``spatter-devel``
- [x] Reviewers Requested
- [ ] Projects associated
- [ ] Commits mention issue and/or PR numbers at the bottom of the message
- [x] Relevant issues are linked into the PR
- [x] TODOs are completed
- [ ] Reviewer checklist is updated

## 🚀 TODOs

- [ ] Run Spatter tests on CUDA backend

## 📌 Future Work

- Update Spatter CI workflow to build and run the CUDA backend (currently it only builds)