### PR TITLE
Allow 'gs' to Specify Gather-Scatter Kernel

### DIFF
--- a/src/Spatter/Input.hh
+++ b/src/Spatter/Input.hh
@@ -390,6 +390,10 @@ int parse_input(const int argc, char **argv, ClArgs &cl) {
       kernel = optarg;
       std::transform(kernel.begin(), kernel.end(), kernel.begin(),
           [](unsigned char c) { return std::tolower(c); });
+      
+      // The gather-scatter kernel may be specified as 'gs' instead of 'sg'
+      if (kernel.compare("gs") == 0)
+        kernel = "sg";
 
       if ((kernel.compare("gather") != 0) && (kernel.compare("scatter") != 0) &&
           (kernel.compare("sg") != 0) && (kernel.compare("multigather") != 0) &&


### PR DESCRIPTION
## Overview

This PR updates the command-line parsing to allow both 'gs' and 'sg' to specify the gather-scatter kernel. The argument parsing for JSON files already supports both of these options.

## ✨ Change Description/Rationale

- Gather-Scatter kernel can now be specified with 'gs' from the command-line
- Closes #217 

## 👀 Reviewer Checklist
- [ ] All GitHub actions and runners have passed if applicable
- [ ] Commits are clean and relevant

## ✅ PR Checklist

- [x] Remove or update the template boilerplate text
- [x] Commits are relevant and combined where appropriate
- [x] Rebase off ``spatter-devel``
- [x] Reviewers Requested
- [ ] Projects associated
- [x] Commits mention issue and/or PR numbers at the bottom of the message
- [x] Relevant issues are linked into the PR
- [ ] TODOs are completed
- [ ] Reviewer checklist is updated

## 🚀 TODOs

- [ ] No additional TODOs for this PR

## 📌 Future Work

- No additional future work