### PR TITLE
Make OpenMP dense buffers a command line option

### DIFF
--- a/src/Spatter/Configuration.cc
+++ b/src/Spatter/Configuration.cc
@@ -557,11 +557,13 @@ void Configuration<Spatter::OpenMP>::gather(bool timed, unsigned long run_id) {
 #pragma omp parallel
   {
     int t = omp_get_thread_num();
+    double *source = sparse.data();
+    double *target = (target_buffers ? dense_perthread[t].data() : dense.data());
 
 #pragma omp for
     for (size_t i = 0; i < count; ++i) {
-      double *sl = sparse.data() + delta * i;
-      double *tl = dense_perthread[t].data() + pattern_length * (i % wrap);
+      double *sl = source + delta * i;
+      double *tl = target + pattern_length * (i % wrap);
 
 #pragma omp simd
       for (size_t j = 0; j < pattern_length; ++j) {
@@ -591,11 +593,13 @@ void Configuration<Spatter::OpenMP>::scatter(bool timed, unsigned long run_id) {
 #pragma omp parallel
   {
     int t = omp_get_thread_num();
+    double *source = (target_buffers ? dense_perthread[t].data() : dense.data());
+    double *target = sparse.data();
 
 #pragma omp for
     for (size_t i = 0; i < count; ++i) {
-      double *tl = sparse.data() + delta * i;
-      double *sl = dense_perthread[t].data() + pattern_length * (i % wrap);
+      double *tl = target + delta * i;
+      double *sl = source + pattern_length * (i % wrap);
 
 #pragma omp simd
       for (size_t j = 0; j < pattern_length; ++j) {
@@ -655,11 +659,13 @@ void Configuration<Spatter::OpenMP>::multi_gather(
 #pragma omp parallel
   {
     int t = omp_get_thread_num();
+    double *source = sparse.data();
+    double *target = (target_buffers ? dense_perthread[t].data() : dense.data());
 
 #pragma omp for
     for (size_t i = 0; i < count; ++i) {
-      double *sl = sparse.data() + delta * i;
-      double *tl = dense_perthread[t].data() + pattern_length * (i % wrap);
+      double *sl = source + delta * i;
+      double *tl = target + pattern_length * (i % wrap);
 
 #pragma omp simd
       for (size_t j = 0; j < pattern_length; ++j) {
@@ -690,11 +696,13 @@ void Configuration<Spatter::OpenMP>::multi_scatter(
 #pragma omp parallel
   {
     int t = omp_get_thread_num();
+    double *target = sparse.data();
+    double *source = (target_buffers ? dense_perthread[t].data() : dense.data());
 
 #pragma omp for
     for (size_t i = 0; i < count; ++i) {
-      double *tl = sparse.data() + delta * i;
-      double *sl = dense_perthread[t].data() + pattern_length * (i % wrap);
+      double *tl = target + delta * i;
+      double *sl = source + pattern_length * (i % wrap);
 
 #pragma omp simd
       for (size_t j = 0; j < pattern_length; ++j) {

--- a/src/Spatter/Configuration.cc
+++ b/src/Spatter/Configuration.cc
@@ -23,7 +23,7 @@ ConfigurationBase::ConfigurationBase(const size_t id, const std::string name,
     const size_t delta_scatter, const long int seed, const size_t wrap,
     const size_t count, const size_t shared_mem, const size_t local_work_size,
     const int nthreads, const unsigned long nruns, const bool aggregate,
-    const bool atomic, const unsigned long verbosity)
+    const bool atomic, const bool target_buffers, const unsigned long verbosity)
     : id(id), name(name), kernel(k), pattern(pattern),
       pattern_gather(pattern_gather), pattern_scatter(pattern_scatter),
       sparse(sparse), dev_sparse(dev_sparse), sparse_size(sparse_size),
@@ -36,7 +36,8 @@ ConfigurationBase::ConfigurationBase(const size_t id, const std::string name,
       delta_scatter(delta_scatter), seed(seed), wrap(wrap), count(count),
       shmem(shared_mem), local_work_size(local_work_size),
       omp_threads(nthreads), nruns(nruns), aggregate(aggregate), atomic(atomic),
-      verbosity(verbosity), time_seconds(nruns, 0) {
+      target_buffers(target_buffers), verbosity(verbosity),
+      time_seconds(nruns, 0) {
   std::transform(kernel.begin(), kernel.end(), kernel.begin(),
       [](unsigned char c) { return std::tolower(c); });
 }
@@ -395,7 +396,7 @@ Configuration<Spatter::Serial>::Configuration(const size_t id,
           dev_sparse_scatter, sparse_scatter_size, dense, dense_perthread,
           dev_dense, dense_size, delta, delta_gather,
           delta_scatter, seed, wrap, count, 0, 1024, 1, nruns, aggregate, false,
-          verbosity) {
+          false, verbosity) {
   ConfigurationBase::setup();
 }
 
@@ -527,13 +528,14 @@ Configuration<Spatter::OpenMP>::Configuration(const size_t id,
     const size_t delta_gather, const size_t delta_scatter, const long int seed,
     const size_t wrap, const size_t count, const int nthreads,
     const unsigned long nruns, const bool aggregate, const bool atomic,
-    const unsigned long verbosity)
+    const bool target_buffers, const unsigned long verbosity)
     : ConfigurationBase(id, name, kernel, pattern, pattern_gather,
           pattern_scatter, sparse, dev_sparse, sparse_size, sparse_gather,
           dev_sparse_gather, sparse_gather_size, sparse_scatter,
           dev_sparse_scatter, sparse_scatter_size, dense, dense_perthread,
           dev_dense, dense_size, delta, delta_gather, delta_scatter, seed, wrap,
-          count, 0, 1024, nthreads, nruns, aggregate, atomic, verbosity) {
+          count, 0, 1024, nthreads, nruns, aggregate, atomic, target_buffers,
+          verbosity) {
   ConfigurationBase::setup();
 }
 
@@ -732,7 +734,7 @@ Configuration<Spatter::CUDA>::Configuration(const size_t id,
           dev_sparse_scatter, sparse_scatter_size, dense, dense_perthread,
           dev_dense, dense_size, delta, delta_gather, delta_scatter, seed,
           wrap, count, shared_mem, local_work_size, 1, nruns, aggregate, atomic,
-          verbosity) {
+          false, verbosity) {
   
   setup();
 }

--- a/src/Spatter/Configuration.hh
+++ b/src/Spatter/Configuration.hh
@@ -69,7 +69,7 @@ public:
       const long int seed, const size_t wrap, const size_t count,
       const size_t shared_mem, const size_t local_work_size, const int nthreads,
       const unsigned long nruns, const bool aggregate, const bool atomic,
-      const bool target_buffers, const unsigned long verbosity);
+      const bool dense_buffers, const unsigned long verbosity);
 
   virtual ~ConfigurationBase();
 
@@ -137,7 +137,7 @@ public:
 
   const bool aggregate;
   const bool atomic;
-  const bool target_buffers;
+  const bool dense_buffers;
   const unsigned long verbosity;
 
   Spatter::Timer timer;
@@ -190,7 +190,7 @@ public:
       const size_t delta_gather, const size_t delta_scatter,
       const long int seed, const size_t wrap, const size_t count,
       const int nthreads, const unsigned long nruns, const bool aggregate,
-      const bool atomic, const bool target_buffers,
+      const bool atomic, const bool dense_buffers,
       const unsigned long verbosity);
 
   int run(bool timed, unsigned long run_id);

--- a/src/Spatter/Configuration.hh
+++ b/src/Spatter/Configuration.hh
@@ -69,7 +69,7 @@ public:
       const long int seed, const size_t wrap, const size_t count,
       const size_t shared_mem, const size_t local_work_size, const int nthreads,
       const unsigned long nruns, const bool aggregate, const bool atomic,
-      const unsigned long verbosity);
+      const bool target_buffers, const unsigned long verbosity);
 
   virtual ~ConfigurationBase();
 
@@ -137,6 +137,7 @@ public:
 
   const bool aggregate;
   const bool atomic;
+  const bool target_buffers;
   const unsigned long verbosity;
 
   Spatter::Timer timer;
@@ -189,7 +190,8 @@ public:
       const size_t delta_gather, const size_t delta_scatter,
       const long int seed, const size_t wrap, const size_t count,
       const int nthreads, const unsigned long nruns, const bool aggregate,
-      const bool atomic, const unsigned long verbosity);
+      const bool atomic, const bool target_buffers,
+      const unsigned long verbosity);
 
   int run(bool timed, unsigned long run_id);
 

--- a/src/Spatter/Input.hh
+++ b/src/Spatter/Input.hh
@@ -32,7 +32,7 @@ const option longargs[] = {{"aggregate", no_argument, nullptr, 'a'},
     {"backend", required_argument, nullptr, 'b'},
     {"compress", no_argument, nullptr, 'c'},
     {"delta", required_argument, nullptr, 'd'},
-    {"dense-buffers", optional_argument, nullptr, 1},
+    {"dense-buffers", required_argument, nullptr, 0},
     {"boundary", required_argument, nullptr, 'e'},
     {"file", required_argument, nullptr, 'f'},
     {"pattern-gather", required_argument, nullptr, 'g'},
@@ -703,15 +703,8 @@ int parse_input(const int argc, char **argv, ClArgs &cl) {
       cl.sparse_scatter[i] = rand();
   }
 
-  if (cl.dense.size() < cl.dense_size) {
-    cl.dense.resize(cl.dense_size);
-
-    for (size_t i = 0; i < cl.dense.size(); ++i)
-      cl.dense[i] = rand();
-  }
-
 #ifdef USE_OPENMP
-  if (backend.compare("openmp") == 0) {
+  if ((backend.compare("openmp") == 0) && dense_buffers) {
     cl.dense_perthread.resize(nthreads);
 
     for (int j = 0; j < nthreads; ++j) {
@@ -720,6 +713,20 @@ int parse_input(const int argc, char **argv, ClArgs &cl) {
       for (size_t i = 0; i < cl.dense_perthread[j].size(); ++i)
         cl.dense_perthread[j][i] = rand();
     }
+  } else {
+      if (cl.dense.size() < cl.dense_size) {
+        cl.dense.resize(cl.dense_size);
+
+      for (size_t i = 0; i < cl.dense.size(); ++i)
+        cl.dense[i] = rand();
+    }
+  }
+#else
+  if (cl.dense.size() < cl.dense_size) {
+    cl.dense.resize(cl.dense_size);
+
+    for (size_t i = 0; i < cl.dense.size(); ++i)
+      cl.dense[i] = rand();
   }
 #endif
 #ifdef USE_CUDA

--- a/src/Spatter/Input.hh
+++ b/src/Spatter/Input.hh
@@ -32,7 +32,7 @@ const option longargs[] = {{"aggregate", no_argument, nullptr, 'a'},
     {"backend", required_argument, nullptr, 'b'},
     {"compress", no_argument, nullptr, 'c'},
     {"delta", required_argument, nullptr, 'd'},
-    {"dense-buffers", required_argument, nullptr, 0},
+    {"dense-buffers", no_argument, nullptr, 0},
     {"boundary", required_argument, nullptr, 'e'},
     {"file", required_argument, nullptr, 'f'},
     {"pattern-gather", required_argument, nullptr, 'g'},
@@ -139,7 +139,7 @@ void help(char *progname) {
   std::cout << std::left << std::setw(10) << "   (--dense-buffers) "
             << std::setw(40)
             << "Enable multiple dense buffers for OpenMP kernels "
-            << "(default 0/off)" << std::left << "\n";
+            << "(default off)" << std::left << "\n";
   std::cout << std::left << std::setw(10) << "-e (--boundary)" << std::setw(40)
             << " Set Boundary (limits max value of pattern using modulo)"
             << std::left << "\n";
@@ -331,12 +331,7 @@ int parse_input(const int argc, char **argv, ClArgs &cl) {
         atomic = (atomic_val > 0) ? true : false;
       }
       if (strcmp(longargs[option_index].name, "dense-buffers") == 0) {
-        int dense_buffers_val = 0;
-        if (read_int_arg(optarg, dense_buffers_val,
-                  "Parsing Error: Invalid Dense Buffers") == -1) {
-          return -1;
-        }
-        dense_buffers = dense_buffers_val > 0;
+        dense_buffers = true;
       }
       break;
 

--- a/src/Spatter/JSONParser.cc
+++ b/src/Spatter/JSONParser.cc
@@ -16,11 +16,10 @@ JSONParser::JSONParser(std::string filename, aligned_vector<double> &sparse,
     aligned_vector<double> &dense,
     aligned_vector<aligned_vector<double>> &dense_perthread, double *&dev_dense,
     size_t &dense_size, const std::string backend, const bool aggregate,
-    const bool atomic, const bool compress, size_t shared_mem,
-    const int nthreads, const bool target_buffers,
-    const unsigned long verbosity, const std::string name,
-    const std::string kernel, const size_t pattern_size, const size_t delta,
-    const size_t delta_gather, const size_t delta_scatter,
+    const bool atomic, const bool compress, const bool dense_buffers,
+    size_t shared_mem, const int nthreads, const unsigned long verbosity,
+    const std::string name, const std::string kernel, const size_t pattern_size,
+    const size_t delta, const size_t delta_gather, const size_t delta_scatter,
     const size_t boundary, const long int seed, const size_t wrap,
     const size_t count, const size_t local_work_size, const unsigned long nruns)
     : sparse(sparse), dev_sparse(dev_sparse), sparse_size(sparse_size),
@@ -30,11 +29,11 @@ JSONParser::JSONParser(std::string filename, aligned_vector<double> &sparse,
       sparse_scatter_size(sparse_scatter_size), dense(dense),
       dense_perthread(dense_perthread), dev_dense(dev_dense),
       dense_size(dense_size), backend_(backend), aggregate_(aggregate),
-      atomic_(atomic), compress_(compress), shared_mem_(shared_mem),
-      omp_threads_(nthreads), target_buffers_(target_buffers),
-      verbosity_(verbosity), default_name_(name),
-      default_kernel_(kernel), default_pattern_size_(pattern_size),
-      default_delta_(delta), default_delta_gather_(delta_gather),
+      atomic_(atomic), compress_(compress), dense_buffers_(dense_buffers),
+      shared_mem_(shared_mem), omp_threads_(nthreads), verbosity_(verbosity),
+      default_name_(name), default_kernel_(kernel),
+      default_pattern_size_(pattern_size), default_delta_(delta),
+      default_delta_gather_(delta_gather),
       default_delta_scatter_(delta_scatter), default_boundary_(boundary),
       default_seed_(seed), default_wrap_(wrap), default_count_(count),
       default_local_work_size_(local_work_size), default_nruns_(nruns) {
@@ -204,7 +203,7 @@ std::unique_ptr<Spatter::ConfigurationBase> JSONParser::operator[](
         dev_dense, dense_size, delta, delta_gather, delta_scatter,
         data_[index]["seed"], data_[index]["wrap"], data_[index]["count"],
         omp_threads_, data_[index]["nruns"], aggregate_, atomic_,
-        target_buffers_, verbosity_);
+        dense_buffers_, verbosity_);
 #endif
 #ifdef USE_CUDA
   else if (backend_.compare("cuda") == 0)

--- a/src/Spatter/JSONParser.cc
+++ b/src/Spatter/JSONParser.cc
@@ -17,7 +17,8 @@ JSONParser::JSONParser(std::string filename, aligned_vector<double> &sparse,
     aligned_vector<aligned_vector<double>> &dense_perthread, double *&dev_dense,
     size_t &dense_size, const std::string backend, const bool aggregate,
     const bool atomic, const bool compress, size_t shared_mem,
-    const int nthreads, const unsigned long verbosity, const std::string name,
+    const int nthreads, const bool target_buffers,
+    const unsigned long verbosity, const std::string name,
     const std::string kernel, const size_t pattern_size, const size_t delta,
     const size_t delta_gather, const size_t delta_scatter,
     const size_t boundary, const long int seed, const size_t wrap,
@@ -30,7 +31,8 @@ JSONParser::JSONParser(std::string filename, aligned_vector<double> &sparse,
       dense_perthread(dense_perthread), dev_dense(dev_dense),
       dense_size(dense_size), backend_(backend), aggregate_(aggregate),
       atomic_(atomic), compress_(compress), shared_mem_(shared_mem),
-      omp_threads_(nthreads), verbosity_(verbosity), default_name_(name),
+      omp_threads_(nthreads), target_buffers_(target_buffers),
+      verbosity_(verbosity), default_name_(name),
       default_kernel_(kernel), default_pattern_size_(pattern_size),
       default_delta_(delta), default_delta_gather_(delta_gather),
       default_delta_scatter_(delta_scatter), default_boundary_(boundary),
@@ -201,7 +203,8 @@ std::unique_ptr<Spatter::ConfigurationBase> JSONParser::operator[](
         dev_sparse_scatter, sparse_scatter_size, dense, dense_perthread,
         dev_dense, dense_size, delta, delta_gather, delta_scatter,
         data_[index]["seed"], data_[index]["wrap"], data_[index]["count"],
-        omp_threads_, data_[index]["nruns"], aggregate_, atomic_, verbosity_);
+        omp_threads_, data_[index]["nruns"], aggregate_, atomic_,
+        target_buffers_, verbosity_);
 #endif
 #ifdef USE_CUDA
   else if (backend_.compare("cuda") == 0)

--- a/src/Spatter/JSONParser.hh
+++ b/src/Spatter/JSONParser.hh
@@ -35,7 +35,7 @@ public:
       aligned_vector<aligned_vector<double>> &dense_perthread,
       double *&dev_dense, size_t &dense_size, const std::string backend,
       const bool aggregate, const bool atomic, const bool compress,
-      const size_t shared_mem, const int nthreads, const bool target_buffers,
+      const bool dense_buffers, const size_t shared_mem, const int nthreads,
       const unsigned long verbosity, const std::string name = "",
       const std::string kernel = "gather", const size_t pattern_size = 0,
       const size_t delta = 8, const size_t delta_gather = 8,
@@ -78,9 +78,9 @@ private:
   const bool aggregate_;
   const bool atomic_;
   const bool compress_;
+  const bool dense_buffers_;
   const size_t shared_mem_;
   const int omp_threads_;
-  const bool target_buffers_;
   const unsigned long verbosity_;
 
   std::string default_name_;

--- a/src/Spatter/JSONParser.hh
+++ b/src/Spatter/JSONParser.hh
@@ -35,7 +35,7 @@ public:
       aligned_vector<aligned_vector<double>> &dense_perthread,
       double *&dev_dense, size_t &dense_size, const std::string backend,
       const bool aggregate, const bool atomic, const bool compress,
-      const size_t shared_mem, const int nthreads,
+      const size_t shared_mem, const int nthreads, const bool target_buffers,
       const unsigned long verbosity, const std::string name = "",
       const std::string kernel = "gather", const size_t pattern_size = 0,
       const size_t delta = 8, const size_t delta_gather = 8,
@@ -80,6 +80,7 @@ private:
   const bool compress_;
   const size_t shared_mem_;
   const int omp_threads_;
+  const bool target_buffers_;
   const unsigned long verbosity_;
 
   std::string default_name_;

--- a/tests/parse_run_config_suite_cpu.cc
+++ b/tests/parse_run_config_suite_cpu.cc
@@ -158,6 +158,33 @@ int d_tests(int argc_, char **argv_) {
   return EXIT_SUCCESS;
 }
 
+int dense_buffers_tests(int argc_, char **argv_) {
+#ifdef USE_OPENMP
+  asprintf(&argv_[2], "--dense-buffers");
+
+  Spatter::ClArgs cl1;
+  if (parse_check(argc_, argv_, cl1) == EXIT_FAILURE)
+    return EXIT_FAILURE;
+
+  free(argv_[2]);
+
+  if (cl1.configs[0]->dense_buffers != true) {
+    std::cerr << "Test failure on Run_Config Suite: --dense-buffers with no "
+                 "argument had incorrect value of "
+              << cl1.configs[0]->dense_buffers << "." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  if (cl1.configs[0]->dense.size() != 0) {
+    std::cerr << "Test failure on Run_Config Suite: Expected size of dense "
+              << "buffer to be 0, actually was "
+              << cl1.configs[0]->dense.size() << std::endl;
+    return EXIT_FAILURE;
+  }
+#endif
+  return EXIT_SUCCESS;
+}
+
 int l_tests(int argc_, char **argv_) {
   asprintf(&argv_[2], "-l100");
 
@@ -376,6 +403,9 @@ int main(int argc, char **argv) {
 
   // delta d
   if (d_tests(argc_, argv_) != EXIT_SUCCESS)
+    return EXIT_FAILURE;
+
+  if (dense_buffers_tests(argc_, argv_) != EXIT_SUCCESS)
     return EXIT_FAILURE;
 
   // count l


### PR DESCRIPTION
## Overview

This PR adds the `--dense-buffers` command-line option to enable the use of multiple dense buffers in the OpenMP kernels. The OpenMP kernels will now default to using a single dense buffer.

## ✨ Change Description/Rationale

- Added `--dense-buffers` command-line option
- Updated OpenMP kernels to use either `dense_perthread` or `dense` buffers
- Added tests for the `--dense-buffers` option
- Closes #191 

## 👀 Reviewer Checklist
- [ ] All GitHub actions and runners have passed if applicable
- [ ] Commits are clean and relevant

## ✅ PR Checklist

- [x] Remove or update the template boilerplate text
- [x] Commits are relevant and combined where appropriate
- [x] Rebase off ``spatter-devel``
- [x] Reviewers Requested
- [ ] Projects associated
- [ ] Commits mention issue and/or PR numbers at the bottom of the message
- [x] Relevant issues are linked into the PR
- [ ] TODOs are completed
- [ ] Reviewer checklist is updated
