### PR TITLE
Print Current Version of Spatter

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,7 @@ add_executable(spatter main.cc)
 #target_compile_options(spatter PUBLIC "-fnew-alignment 32")
 target_link_libraries(spatter ${COMMON_LINK_LIBRARIES} Spatter)
 set_target_properties(spatter PROPERTIES
-    COMPILE_DEFINITIONS "${COMMON_COMPILE_DEFINITIONS}"
+    COMPILE_DEFINITIONS "${COMMON_COMPILE_DEFINITIONS};SPAT_VERSION=${PROJECT_VERSION}"
     COMPILE_OPTIONS "${WARNING_FLAGS}"
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
     )

--- a/src/main.cc
+++ b/src/main.cc
@@ -10,7 +10,7 @@
 
 void print_build_info(Spatter::ClArgs &cl) {
   std::cout << std::endl;
-  std::cout << "Running Spatter version 1.1" << std::endl;
+  std::cout << "Running Spatter version " << xstr(SPAT_VERSION) << std::endl;
   std::cout << "Compiler: " << xstr(SPAT_CXX_NAME) << " ver. "
             << xstr(SPAT_CXX_VER) << std::endl;
   std::cout << "Backend: ";


### PR DESCRIPTION
## Overview

This PR updates Spatter to print the current version during runs, as set by `project()` in the top-level CMakeLists.txt file.

## ✨ Change Description/Rationale
- Spatter now prints version 2.0.0 instead of version 1.1
- Closes #224 

## 👀 Reviewer Checklist
- [ ] All GitHub actions and runners have passed if applicable
- [x] Commits are clean and relevant

## ✅ PR Checklist

- [x] Remove or update the template boilerplate text
- [x] Commits are relevant and combined where appropriate
- [x] Rebase off ``spatter-devel``
- [x] Reviewers Requested
- [x] Projects associated
- [x] Commits mention issue and/or PR numbers at the bottom of the message
- [x] Relevant issues are linked into the PR
- [x] TODOs are completed
- [x] Reviewer checklist is updated