### PR TITLE
Split Standard Suite Tests

### DIFF
--- a/standard-suite/basic-tests/gpu-stream.json
+++ b/standard-suite/basic-tests/gpu-stream.json
@@ -1,6 +1,6 @@
 [
-    {"pattern":"UNIFORM:256:1:NR", "count":4194304, "kernel":"Gather", "local-work-size":1024},
-    {"pattern":"UNIFORM:256:1:NR", "count":4194304, "kernel":"Scatter", "local-work-size":1024},
+    {"pattern":"UNIFORM:256:1:NR", "kernel":"Gather", "local-work-size":1024},
+    {"pattern":"UNIFORM:256:1:NR", "kernel":"Scatter", "local-work-size":1024},
     {"pattern-gather": "UNIFORM:256:1:NR", "pattern-scatter": "UNIFORM:256:1:NR", "kernel": "GS", "local-work-size":1024},
     {"pattern": "UNIFORM:256:1:NR", "pattern-scatter": "UNIFORM:256:1:NR", "kernel": "MultiScatter", "local-work-size":1024},
     {"pattern": "UNIFORM:256:1:NR", "pattern-gather": "UNIFORM:256:1:NR", "kernel": "MultiGather", "local-work-size":1024}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,7 +21,9 @@ set(SPATTER_TESTS
       concurrent
       multilevel
       binary-trace
-      standard_suite_cpu
+      standard_suite_stream_cpu
+      standard_suite_uniform_cpu
+      standard_suite_traces_cpu
       standard_laplacian_suite
   )
 
@@ -30,7 +32,11 @@ if (USE_OPENMP)
 endif()
 
 if (USE_CUDA)
-  set(SPATTER_TESTS ${SPATTER_TESTS} standard_suite_gpu parse_run_config_suite_gpu)
+  set(SPATTER_TESTS ${SPATTER_TESTS}
+    standard_suite_stream_gpu
+    standard_suite_uniform_gpu
+    standard_suite_traces_gpu
+    parse_run_config_suite_gpu)
 endif()
 
 foreach (APP ${SPATTER_TESTS})

--- a/tests/standard_suite_stream_cpu.cc
+++ b/tests/standard_suite_stream_cpu.cc
@@ -1,0 +1,27 @@
+#include <iostream>
+#include <vector>
+
+int cpu_stream_test() {
+  char *command;
+
+  int ret = asprintf(&command,
+      "../spatter -f "
+      "../../standard-suite/basic-tests/cpu-stream.json");
+  if (ret == -1 || system(command) != EXIT_SUCCESS) {
+    std::cerr << "Test failure on " << command << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  free(command);
+  return EXIT_SUCCESS;
+}
+
+int main(int argc, char **argv) {
+  (void)argc;
+  (void)argv;
+
+  if (cpu_stream_test() != EXIT_SUCCESS)
+    return EXIT_FAILURE;
+
+  return EXIT_SUCCESS;
+}

--- a/tests/standard_suite_stream_gpu.cc
+++ b/tests/standard_suite_stream_gpu.cc
@@ -1,0 +1,27 @@
+#include <iostream>
+#include <vector>
+
+int gpu_stream_test() {
+  char *command;
+
+  int ret = asprintf(&command,
+      "../spatter -b cuda  -f "
+      "../../standard-suite/basic-tests/gpu-stream.json");
+  if (ret == -1 || system(command) != EXIT_SUCCESS) {
+    std::cerr << "Test failure on " << command << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  free(command);
+  return EXIT_SUCCESS;
+}
+
+int main(int argc, char **argv) {
+  (void)argc;
+  (void)argv;
+
+  if (gpu_stream_test() != EXIT_SUCCESS)
+    return EXIT_FAILURE;
+
+  return EXIT_SUCCESS;
+}

--- a/tests/standard_suite_traces_cpu.cc
+++ b/tests/standard_suite_traces_cpu.cc
@@ -1,36 +1,6 @@
 #include <iostream>
 #include <vector>
 
-int cpu_stream_test() {
-  char *command;
-
-  int ret = asprintf(&command,
-      "../spatter -f "
-      "../../standard-suite/basic-tests/cpu-stream.json");
-  if (ret == -1 || system(command) != EXIT_SUCCESS) {
-    std::cerr << "Test failure on " << command << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  free(command);
-  return EXIT_SUCCESS;
-}
-
-int cpu_ustride_test() {
-  char *command;
-
-  int ret = asprintf(&command,
-      "../spatter -f "
-      "../../standard-suite/basic-tests/cpu-ustride.json");
-  if (ret == -1 || system(command) != EXIT_SUCCESS) {
-    std::cerr << "Test failure on " << command << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  free(command);
-  return EXIT_SUCCESS;
-}
-
 int cpu_amg_test() {
   char *command;
 
@@ -90,12 +60,6 @@ int cpu_pennant_test() {
 int main(int argc, char **argv) {
   (void)argc;
   (void)argv;
-
-  if (cpu_stream_test() != EXIT_SUCCESS)
-    return EXIT_FAILURE;
-
-  if (cpu_ustride_test() != EXIT_SUCCESS)
-    return EXIT_FAILURE;
 
   if (cpu_amg_test() != EXIT_SUCCESS)
     return EXIT_FAILURE;

--- a/tests/standard_suite_traces_gpu.cc
+++ b/tests/standard_suite_traces_gpu.cc
@@ -1,36 +1,6 @@
 #include <iostream>
 #include <vector>
 
-int gpu_stream_test() {
-  char *command;
-
-  int ret = asprintf(&command,
-      "../spatter -b cuda  -f "
-      "../../standard-suite/basic-tests/gpu-stream.json");
-  if (ret == -1 || system(command) != EXIT_SUCCESS) {
-    std::cerr << "Test failure on " << command << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  free(command);
-  return EXIT_SUCCESS;
-}
-
-int gpu_ustride_test() {
-  char *command;
-
-  int ret = asprintf(&command,
-      "../spatter -b cuda  -f "
-      "../../standard-suite/basic-tests/gpu-ustride.json");
-  if (ret == -1 || system(command) != EXIT_SUCCESS) {
-    std::cerr << "Test failure on " << command << std::endl;
-    return EXIT_FAILURE;
-  }
-
-  free(command);
-  return EXIT_SUCCESS;
-}
-
 int gpu_amg_test() {
   char *command;
 
@@ -95,16 +65,15 @@ int main(int argc, char **argv) {
   (void)argc;
   (void)argv;
 
-  if (gpu_stream_test() != EXIT_SUCCESS)
-    return EXIT_FAILURE;
-  if (gpu_ustride_test() != EXIT_SUCCESS)
-    return EXIT_FAILURE;
   if (gpu_amg_test() != EXIT_SUCCESS)
     return EXIT_FAILURE;
+
   if (gpu_lulesh_test() != EXIT_SUCCESS)
     return EXIT_FAILURE;
+
   if (gpu_nekbone_test() != EXIT_SUCCESS)
     return EXIT_FAILURE;
+
   if (gpu_pennant_test() != EXIT_SUCCESS)
     return EXIT_FAILURE;
 

--- a/tests/standard_suite_uniform_cpu.cc
+++ b/tests/standard_suite_uniform_cpu.cc
@@ -1,0 +1,27 @@
+#include <iostream>
+#include <vector>
+
+int cpu_ustride_test() {
+  char *command;
+
+  int ret = asprintf(&command,
+      "../spatter -f "
+      "../../standard-suite/basic-tests/cpu-ustride.json");
+  if (ret == -1 || system(command) != EXIT_SUCCESS) {
+    std::cerr << "Test failure on " << command << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  free(command);
+  return EXIT_SUCCESS;
+}
+
+int main(int argc, char **argv) {
+  (void)argc;
+  (void)argv;
+
+  if (cpu_ustride_test() != EXIT_SUCCESS)
+    return EXIT_FAILURE;
+
+  return EXIT_SUCCESS;
+}

--- a/tests/standard_suite_uniform_gpu.cc
+++ b/tests/standard_suite_uniform_gpu.cc
@@ -1,0 +1,27 @@
+#include <iostream>
+#include <vector>
+
+int gpu_ustride_test() {
+  char *command;
+
+  int ret = asprintf(&command,
+      "../spatter -b cuda  -f "
+      "../../standard-suite/basic-tests/gpu-ustride.json");
+  if (ret == -1 || system(command) != EXIT_SUCCESS) {
+    std::cerr << "Test failure on " << command << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  free(command);
+  return EXIT_SUCCESS;
+}
+
+int main(int argc, char **argv) {
+  (void)argc;
+  (void)argv;
+
+  if (gpu_ustride_test() != EXIT_SUCCESS)
+    return EXIT_FAILURE;
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Overview

This PR splits the standard suite test into separate tests for STREAM-like, uniform stride, and application trace patterns; similar to the [GettingStarted.ipynb](https://github.com/hpcgarage/spatter/blob/spatter-devel/notebooks/GettingStarted.ipynb) notebook. Additionally, this PR updates the patterns in the GPU STREAM-like test to use the default count for all kernels.

## ✨ Change Description/Rationale

- standard_suite_cpu and standard_suite_gpu split into separate tests
- gpu-stream.json now uses same count for all patterns

## 👀 Reviewer Checklist
- [ ] All GitHub actions and runners have passed if applicable
- [ ] Commits are clean and relevant

## ✅ PR Checklist

- [x] Remove or update the template boilerplate text
- [x] Commits are relevant and combined where appropriate
- [x] Rebase off ``spatter-devel``
- [x] Reviewers Requested
- [ ] Projects associated
- [ ] Commits mention issue and/or PR numbers at the bottom of the message
- [ ] Relevant issues are linked into the PR
- [ ] TODOs are completed
- [ ] Reviewer checklist is updated

## 🚀 TODOs

- [ ] Add items to this TODO list that shouldn't be forgotten, or that reviewers have requested that you complete.

## 📌 Future Work

- No additional TODOs for this PR