### PR TITLE
Spatter Build Instructions and Intel Backend Fixes

### DIFF
--- a/Build.md
+++ b/Build.md
@@ -45,6 +45,9 @@ JSON support via `nlohmann/json v3.11.2` is automatically fetched via CMake's `F
 
 ## Backend Build Examples
 
+> **Note:** We recommend using the syntax `build_<backend>` to build Spatter backends, which makes it easier to distinguish different variants of the executable.
+
+
 ### Serial (CPU only)
 
 Any supported C++ compiler works, and no backend flags are required.
@@ -57,15 +60,15 @@ cmake --build build -j
 ### OpenMP
 
 ```bash
-cmake -B build -DUSE_OPENMP=ON
-cmake --build build -j
+cmake -B build_omp -DUSE_OPENMP=ON
+cmake --build build_omp -j
 ```
 
 The OpenMP backend can be combined with the MPI backend:
 
 ```bash
-cmake -B build -DUSE_OPENMP=ON -DUSE_MPI=ON
-cmake --build build -j
+cmake -B build_omp_mpi -DUSE_OPENMP=ON -DUSE_MPI=ON
+cmake --build build_omp_mpi -j
 ```
 
 ### CUDA (NVIDIA GPUs)
@@ -73,30 +76,30 @@ cmake --build build -j
 The CUDA backend requires the CUDA Toolkit and a CUDA-capable compiler (`nvcc`) to be on `PATH`. CMake will auto-detect the installed CUDA toolkit.
 
 ```bash
-cmake -B build -DUSE_CUDA=ON
-cmake --build build -j
+cmake -B build_cuda -DUSE_CUDA=ON
+cmake --build build_cuda -j
 ```
  If multiple CUDA versions are installed, you can point CMake at the preferred one as follows:
 
 ```bash
-cmake -B build -DUSE_CUDA=ON -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc
-cmake --build build -j
+cmake -B build_cuda12 -DUSE_CUDA=ON -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc
+cmake --build build_cuda12 -j
 ```
 
-### HIP (AMD GPUs / ROCm)
+### HIP (AMD GPUs)
 
 The HIP backend requires the ROCm Toolkit and a HIP-capable C++ compiler (`hipcc`) to be on `PATH`.  The default ROCm path is `/opt/rocm`, but this can be overriden with `-DHIP_PATH=<path>`.
 
 ```bash
-cmake -B build -DUSE_HIP=ON -DCMAKE_CXX_COMPILER=hipcc
-cmake --build build -j
+cmake -B build_hip -DUSE_HIP=ON -DCMAKE_CXX_COMPILER=hipcc
+cmake --build build_hip -j
 ```
 
 With a non-default ROCm installation:
 
 ```bash
-cmake -B build -DUSE_HIP=ON -DCMAKE_CXX_COMPILER=hipcc -DHIP_PATH=/opt/<rocm-custom>
-cmake --build build -j
+cmake -B build_hip -DUSE_HIP=ON -DCMAKE_CXX_COMPILER=hipcc -DHIP_PATH=/opt/<rocm-custom>
+cmake --build build_hip -j
 ```
 
 ### OneAPI (Intel GPUs / SYCL)
@@ -104,8 +107,8 @@ cmake --build build -j
 The OneAPI backend requires the OneAPI Toolkit and a SYCL-capable C++ compiler (`icpx`) to be on `PATH`. You can typically set `icpx` to be on your path using environment variables or the `setvars.sh` script included with OneAPI installations.
 
 ```bash
-cmake -B build -DUSE_ONEAPI=ON -DCMAKE_CXX_COMPILER=icpx
-cmake --build build -j
+cmake -B build_oneapi -DUSE_ONEAPI=ON -DCMAKE_CXX_COMPILER=icpx
+cmake --build build_oneapi -j
 ```
 
 ---

--- a/Build.md
+++ b/Build.md
@@ -1,31 +1,141 @@
-# Supported configurations
+# Building Spatter
 
-## Serial 
-### Supported Compilers
-* gnu
-* cray
+Spatter uses CMake (currently ≥ 3.25) and requires a C++17-compatible compiler.
 
-# Cuda 
-### Supported Compilers and optional arguments
-* nvcc
-    * `-DCUDA_ARCH=<ARCH>`
-        * Default is 7.0
-        * For example to set it to 7.0, enter `-DCUDA_ARCH=70`
+## Quick Start
 
-## Openmp
-### Supported Compilers and optional arguments
-* gnu
-    * `-DUSE_MPI=1`
-* cray
-    * `-DUSE_PAPI=1`
-    * `-DUSE_SVE=1`
-* clang
-* armclang (wombat)
-* xl
-* intel
-    * `-DINTEL_PLATFORM=<PLATFORM>`
-        * skylake
-        * avx_crossplatform
-        * non_avx
-    * `-DUSE_MPI=1`
-    * `-DUSE_PAPI=1`
+```bash
+cmake -B build [options]
+cmake --build build -j
+```
+
+The compiled `spatter` binary will be placed in the `build/` directory in this example.
+
+## Installation
+
+```bash
+cmake --install build --prefix /path/to/install
+```
+
+This installs the `spatter` and `gz_read` binaries to `<prefix>/bin/`.
+
+## Spack Installation
+You can also use Spack to install the default (OpenMP) and CUDA versions of Spatter. Please see the [Spack packages](https://packages.spack.io/package.html?name=spatter) for more information.
+
+---
+
+## CMake Options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `USE_CUDA` | `BOOL` | `OFF` | Enable NVIDIA CUDA backend |
+| `USE_HIP` | `BOOL` | `OFF` | Enable AMD HIP/ROCm backend |
+| `USE_ONEAPI` | `BOOL` | `OFF` | Enable Intel OneAPI SYCL backend |
+| `USE_OPENMP` | `BOOL` | `OFF` | Enable OpenMP threading |
+| `USE_MPI` | `BOOL` | `OFF` | Enable MPI support |
+| `CMAKE_BUILD_TYPE` | `STRING` | `Release` | Build type: `Release`, `Debug`, `RelWithDebInfo` |
+| `CMAKE_CXX_COMPILER` | `STRING` | system default | C++ compiler to use |
+
+> **Note:** `USE_CUDA`, `USE_HIP`, and `USE_ONEAPI` are mutually exclusive. Only one GPU backend may be enabled at a time.
+
+## JSON Support
+JSON support via `nlohmann/json v3.11.2` is automatically fetched via CMake's `FetchContent`.
+
+---
+
+## Backend Build Examples
+
+### Serial (CPU only)
+
+Any supported C++ compiler works, and no backend flags are required.
+
+```bash
+cmake -B build
+cmake --build build -j
+```
+
+### OpenMP
+
+```bash
+cmake -B build -DUSE_OPENMP=ON
+cmake --build build -j
+```
+
+The OpenMP backend can be combined with the MPI backend:
+
+```bash
+cmake -B build -DUSE_OPENMP=ON -DUSE_MPI=ON
+cmake --build build -j
+```
+
+### CUDA (NVIDIA GPUs)
+
+The CUDA backend requires the CUDA Toolkit and a CUDA-capable compiler (`nvcc`) to be on `PATH`. CMake will auto-detect the installed CUDA toolkit.
+
+```bash
+cmake -B build -DUSE_CUDA=ON
+cmake --build build -j
+```
+ If multiple CUDA versions are installed, you can point CMake at the preferred one as follows:
+
+```bash
+cmake -B build -DUSE_CUDA=ON -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc
+cmake --build build -j
+```
+
+### HIP (AMD GPUs / ROCm)
+
+The HIP backend requires the ROCm Toolkit and a HIP-capable C++ compiler (`hipcc`) to be on `PATH`.  The default ROCm path is `/opt/rocm`, but this can be overriden with `-DHIP_PATH=<path>`.
+
+```bash
+cmake -B build -DUSE_HIP=ON -DCMAKE_CXX_COMPILER=hipcc
+cmake --build build -j
+```
+
+With a non-default ROCm installation:
+
+```bash
+cmake -B build -DUSE_HIP=ON -DCMAKE_CXX_COMPILER=hipcc -DHIP_PATH=/opt/<rocm-custom>
+cmake --build build -j
+```
+
+### OneAPI (Intel GPUs / SYCL)
+
+The OneAPI backend requires the OneAPI Toolkit and a SYCL-capable C++ compiler (`icpx`) to be on `PATH`. You can typically set `icpx` to be on your path using environment variables or the `setvars.sh` script included with OneAPI installations.
+
+```bash
+cmake -B build -DUSE_ONEAPI=ON -DCMAKE_CXX_COMPILER=icpx
+cmake --build build -j
+```
+
+---
+
+## Supported Compilers
+
+| Compiler | ID | Serial | OpenMP | CUDA | HIP | OneAPI |
+|---|---|:---:|:---:|:---:|:---:|:---:|
+| GCC | `GNU` | ✓ | ✓ | | | |
+| Clang | `Clang` | ✓ | ✓ | | | |
+| Intel (`icpx`) | `IntelLLVM` | ✓ | ✓ | | | ✓ |
+| Cray CCE | `Cray` | ✓ | ✓ | | | |
+| IBM XL | `XL` | ✓ | ✓ | | | |
+| NVCC | `NVIDIA` | | | ✓ | | |
+| `hipcc` | `ROCm (Clang)) | | | | ✓ | |
+
+---
+
+## Build Types
+
+The default build type is `Release`. To change it:
+
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Debug
+```
+or 
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
+```
+
+Debug builds include `-g -debug all`. GCC and Clang builds enable `-Wall -Wextra -Wconversion -pedantic-errors`.
+
+---

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(Spatter VERSION 2.2.0 LANGUAGES CXX)
 
 option(USE_CUDA "Enable CUDA support" OFF)
 option(USE_HIP "Enable HIP support" OFF)
-option(USE_ONEAPI "Enable ONEAPI support" OFF)
+option(USE_ONEAPI "Enable OneAPI support" OFF)
 
 set(SELECTED_COUNT 0)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(Spatter VERSION 2.2.0 LANGUAGES CXX)
 
 option(USE_CUDA "Enable CUDA support" OFF)
 option(USE_HIP "Enable HIP support" OFF)
-option(USE_ONEAPI "Enable HIP support" OFF)
+option(USE_ONEAPI "Enable ONEAPI support" OFF)
 
 set(SELECTED_COUNT 0)
 
@@ -48,8 +48,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 include(pkgs/JSONSupport)
 include(pkgs/MPISupport)
 include(pkgs/OpenMPSupport)
-include(pkgs/CUDASupport)
-include(pkgs/OneAPISupport)
+if(USE_ONEAPI)
+    include(pkgs/OneAPISupport)
+endif()
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -debug all")
 
 if (APPLE)

--- a/cmake/pkgs/OneAPISupport.cmake
+++ b/cmake/pkgs/OneAPISupport.cmake
@@ -1,54 +1,88 @@
-# Option to enable OneAPI
-option(USE_ONEAPI "Enable support for Intel OneAPI" ON)
+# OneAPISupport.cmake
+#
+# IMPORTANT: The Intel DPC++/C++ compiler (icpx) must be selected BEFORE
+# CMake's project() call.  Pass it on the command line:
+#   cmake -DCMAKE_CXX_COMPILER=icpx ...
+# or source Intel's environment script first:
+#   source /opt/intel/oneapi/setvars.sh && cmake -DCMAKE_CXX_COMPILER=icpx ...
 
 if (USE_ONEAPI)
-    # Check for compiler and print debug info
-    include(CheckLanguage)
-    check_language(CXX)
+    # Verify that icpx (IntelLLVM) is actually the active CXX compiler.
+    # CMAKE_CXX_COMPILER cannot be changed after project() has been called.
+    if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "IntelLLVM")
+        message(FATAL_ERROR
+            "USE_ONEAPI requires the Intel DPC++/C++ compiler (icpx/icx).\n"
+            "  Detected: CMAKE_CXX_COMPILER_ID=${CMAKE_CXX_COMPILER_ID}"
+            " (${CMAKE_CXX_COMPILER})\n"
+            "  Reconfigure with: -DCMAKE_CXX_COMPILER=icpx\n"
+            "  or source Intel's setvars.sh before running cmake.")
+    endif()
 
-    message(STATUS "CMAKE_CXX_COMPILER: ${CMAKE_CXX_COMPILER}")
-    message(STATUS "CMAKE_CXX_COMPILER_ID: ${CMAKE_CXX_COMPILER_ID}")
+    message(STATUS "OneAPI DPC++ compiler (IntelLLVM) detected: ${CMAKE_CXX_COMPILER}")
 
-    # Explicitly check if the compiler is IntelLLVM (DPC++)
-    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "IntelLLVM")
-        message(STATUS "OneAPI DPC++ compiler (IntelLLVM) detected: ${CMAKE_CXX_COMPILER}")
+    # -fsycl is required for SYCL device compilation
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsycl")
 
-        # Set compiler flags
-        set(CMAKE_CXX_STANDARD 17)
-        set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    add_definitions(-DUSE_ONEAPI)
 
-        # Define a preprocessor directive for OneAPI support
-        add_definitions(-DUSE_ONEAPI)
-
-        # First try finding IntelSYCL (New recommended package)
-        set(IntelSYCL_DIR "/net/projects/tools/x86_64/rhel-8/intel-oneapi/2024.2/compiler/latest/lib/cmake/sycl")
-        find_package(IntelSYCL REQUIRED)
-
-        if (IntelSYCL_FOUND)
-            message(STATUS "Intel OneAPI SYCL package found.")
-            set(COMMON_LINK_LIBRARIES ${COMMON_LINK_LIBRARIES} IntelSYCL::SYCL_CXX)
+    # ------------------------------------------------------------------
+    # Locate the IntelSYCL CMake package.
+    # Search order:
+    #   1. User-supplied IntelSYCL_DIR cache variable
+    #   2. CMPLR_ROOT environment variable  (set by setvars.sh / modulefiles)
+    #   3. ONEAPI_ROOT environment variable (set by setvars.sh)
+    #   4. Derive from the compiler executable location
+    # ------------------------------------------------------------------
+    if (NOT DEFINED IntelSYCL_DIR)
+        if (DEFINED ENV{CMPLR_ROOT})
+            set(IntelSYCL_DIR "$ENV{CMPLR_ROOT}/lib/cmake/sycl"
+                CACHE PATH "Path to IntelSYCL CMake config")
+        elseif (DEFINED ENV{ONEAPI_ROOT})
+            set(IntelSYCL_DIR "$ENV{ONEAPI_ROOT}/compiler/latest/lib/cmake/sycl"
+                CACHE PATH "Path to IntelSYCL CMake config")
         else()
-            message(WARNING "IntelSYCL::SYCL target not found! Falling back to manual linking.")
+            # Fall back to a path relative to the compiler binary
+            get_filename_component(_icpx_bindir "${CMAKE_CXX_COMPILER}" DIRECTORY)
+            set(IntelSYCL_DIR "${_icpx_bindir}/../lib/cmake/sycl"
+                CACHE PATH "Path to IntelSYCL CMake config")
+        endif()
+    endif()
 
-            # Manually link the Intel SYCL library
-            set(SYCL_LIB_PATH "/net/projects/tools/x86_64/rhel-8/intel-oneapi/2024.2/compiler/2024.2/lib")
+    find_package(IntelSYCL QUIET)
 
-            # Correct OneAPI include path
-            set(SYCL_INCLUDE_PATH "/net/projects/tools/x86_64/rhel-8/intel-oneapi/2024.2/compiler/2024.2/include")
+    if (IntelSYCL_FOUND)
+        message(STATUS "Intel OneAPI SYCL package found (${IntelSYCL_DIR})")
+        set(COMMON_LINK_LIBRARIES ${COMMON_LINK_LIBRARIES} IntelSYCL::SYCL_CXX)
+    else()
+        message(WARNING
+            "IntelSYCL CMake package not found (searched: ${IntelSYCL_DIR}).\n"
+            "Falling back to manual SYCL library linking.")
 
-            include_directories(${SYCL_INCLUDE_PATH})
-            link_directories(${SYCL_LIB_PATH})
-
-            set(COMMON_LINK_LIBRARIES ${COMMON_LINK_LIBRARIES} "${SYCL_LIB_PATH}/libsycl.so")
+        # Derive SYCL lib/include paths with the same priority order
+        if (DEFINED ENV{CMPLR_ROOT})
+            set(_sycl_root "$ENV{CMPLR_ROOT}")
+        elseif (DEFINED ENV{ONEAPI_ROOT})
+            set(_sycl_root "$ENV{ONEAPI_ROOT}/compiler/latest")
+        else()
+            get_filename_component(_icpx_bindir "${CMAKE_CXX_COMPILER}" DIRECTORY)
+            set(_sycl_root "${_icpx_bindir}/..")
         endif()
 
-        # Force CMake to use DPC++ compiler
-        set(CMAKE_CXX_COMPILER icpx)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsycl")
+        set(SYCL_LIB_PATH     "${_sycl_root}/lib")
+        set(SYCL_INCLUDE_PATH "${_sycl_root}/include")
 
+        if (NOT EXISTS "${SYCL_LIB_PATH}/libsycl.so")
+            message(FATAL_ERROR
+                "Could not find libsycl.so under ${SYCL_LIB_PATH}.\n"
+                "Set CMPLR_ROOT or ONEAPI_ROOT, or specify -DIntelSYCL_DIR=<path>.")
+        endif()
+
+        include_directories(${SYCL_INCLUDE_PATH})
+        link_directories(${SYCL_LIB_PATH})
+        set(COMMON_LINK_LIBRARIES ${COMMON_LINK_LIBRARIES} "${SYCL_LIB_PATH}/libsycl.so")
+        message(STATUS "Using manual SYCL library: ${SYCL_LIB_PATH}/libsycl.so")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${SYCL_INCLUDE_PATH}")
-
-    else()
-        message(FATAL_ERROR "OneAPI DPC++ compiler not found. Detected CMAKE_CXX_COMPILER_ID=${CMAKE_CXX_COMPILER_ID}")
     endif()
+
+    message(STATUS "OneAPI support enabled (flags: ${CMAKE_CXX_FLAGS})")
 endif()


### PR DESCRIPTION
## Overview

This PR adds some much needed improvements to Build.md. It also looks to fix the Intel OneAPI cmake package, which was using some hard-coded logic to find the OneAPI compiler.

Closes #252 

## ✨ Change Description/Rationale

- Added details from build files to Build.md
- Removed some spurious lines in CMakeLists.txt
- Used Claude to fix/refactor the OneAPI cmake package file

If a longer explanation is required, it goes in paragraphs below the title sentence.

## 👀 Reviewer Checklist
- [ ] All GitHub actions and runners have passed if applicable
- [ ] Commits are clean and relevant

## ✅ PR Checklist

- [ ] Remove or update the template boilerplate text
- [ ] Commits are relevant and combined where appropriate
- [ ] Rebase off ``spatter-devel``
- [ ] Reviewers Requested
- [ ] Projects associated
- [ ] Commits mention issue and/or PR numbers at the bottom of the message
- [ ] Relevant issues are linked into the PR
- [ ] TODOs are completed
- [ ] Reviewer checklist is updated

## 📌 Future Work

- Build.md may need additional updates as we clean up compiler support.