### PR TITLE
Enable host-native architecture tuning for GNU/Clang builds (fixes #209)

### DIFF
--- a/Build.md
+++ b/Build.md
@@ -1,40 +1,146 @@
-# Supported configurations
+# Building Spatter
 
-## Serial 
-### Supported Compilers
-* gnu
-* cray
+Spatter uses CMake (currently ≥ 3.25) and requires a C++17-compatible compiler.
 
-# Cuda 
-### Supported Compilers and optional arguments
-* nvcc
-    * `-DCUDA_ARCH=<ARCH>`
-        * Default is 7.0
-        * For example to set it to 7.0, enter `-DCUDA_ARCH=70`
+## Quick Start
 
-## Openmp
-### Supported Compilers and optional arguments
-* gnu
-    * `-DUSE_MPI=1`
-    * `-DSPATTER_ENABLE_NATIVE_ARCH=<ON|OFF>`
-        * Default is ON. Tunes the build for the host CPU (adds `-march=native`,
-          or `-mcpu=native` where `-march=native` is unsupported), so the
-          gather/scatter kernels are compiled for the host ISA (e.g. AVX2/AVX-512).
-        * Set to OFF for portable/reproducible binaries or when cross-compiling.
-    * `-DSPATTER_ARCH_FLAGS=<flags>`
-        * Pin a specific target instead of native detection,
-          e.g. `-DSPATTER_ARCH_FLAGS="-march=sapphirerapids"`. Takes precedence
-          over `SPATTER_ENABLE_NATIVE_ARCH`.
-* cray
-    * `-DUSE_PAPI=1`
-    * `-DUSE_SVE=1`
-* clang
-* armclang (wombat)
-* xl
-* intel
-    * `-DINTEL_PLATFORM=<PLATFORM>`
-        * skylake
-        * avx_crossplatform
-        * non_avx
-    * `-DUSE_MPI=1`
-    * `-DUSE_PAPI=1`
+```bash
+cmake -B build [options]
+cmake --build build -j
+```
+
+The compiled `spatter` binary will be placed in the `build/` directory in this example.
+
+## Installation
+
+```bash
+cmake --install build --prefix /path/to/install
+```
+
+This installs the `spatter` and `gz_read` binaries to `<prefix>/bin/`.
+
+## Spack Installation
+You can also use Spack to install the default (OpenMP) and CUDA versions of Spatter. Please see the [Spack packages](https://packages.spack.io/package.html?name=spatter) for more information.
+
+---
+
+## CMake Options
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `USE_CUDA` | `BOOL` | `OFF` | Enable NVIDIA CUDA backend |
+| `USE_HIP` | `BOOL` | `OFF` | Enable AMD HIP/ROCm backend |
+| `USE_ONEAPI` | `BOOL` | `OFF` | Enable Intel OneAPI SYCL backend |
+| `USE_OPENMP` | `BOOL` | `OFF` | Enable OpenMP threading |
+| `USE_MPI` | `BOOL` | `OFF` | Enable MPI support |
+| `CMAKE_BUILD_TYPE` | `STRING` | `Release` | Build type: `Release`, `Debug`, `RelWithDebInfo` |
+| `CMAKE_CXX_COMPILER` | `STRING` | system default | C++ compiler to use |
+| `SPATTER_ENABLE_NATIVE_ARCH` | `BOOL` | `ON` | Tune GNU/Clang builds for the host CPU (adds `-march=native`, or `-mcpu=native` where unsupported) so the gather/scatter kernels use the host ISA (e.g. AVX2/AVX-512). Disable for portable/reproducible or cross builds. |
+| `SPATTER_ARCH_FLAGS` | `STRING` | `""` | Explicit architecture flags for GNU/Clang, e.g. `-march=sapphirerapids`. Takes precedence over `SPATTER_ENABLE_NATIVE_ARCH`. |
+
+> **Note:** `USE_CUDA`, `USE_HIP`, and `USE_ONEAPI` are mutually exclusive. Only one GPU backend may be enabled at a time.
+
+## JSON Support
+JSON support via `nlohmann/json v3.11.2` is automatically fetched via CMake's `FetchContent`.
+
+---
+
+## Backend Build Examples
+
+> **Note:** We recommend using the syntax `build_<backend>` to build Spatter backends, which makes it easier to distinguish different variants of the executable.
+
+
+### Serial (CPU only)
+
+Any supported C++ compiler works, and no backend flags are required.
+
+```bash
+cmake -B build
+cmake --build build -j
+```
+
+### OpenMP
+
+```bash
+cmake -B build_omp -DUSE_OPENMP=ON
+cmake --build build_omp -j
+```
+
+The OpenMP backend can be combined with the MPI backend:
+
+```bash
+cmake -B build_omp_mpi -DUSE_OPENMP=ON -DUSE_MPI=ON
+cmake --build build_omp_mpi -j
+```
+
+### CUDA (NVIDIA GPUs)
+
+The CUDA backend requires the CUDA Toolkit and a CUDA-capable compiler (`nvcc`) to be on `PATH`. CMake will auto-detect the installed CUDA toolkit.
+
+```bash
+cmake -B build_cuda -DUSE_CUDA=ON
+cmake --build build_cuda -j
+```
+ If multiple CUDA versions are installed, you can point CMake at the preferred one as follows:
+
+```bash
+cmake -B build_cuda12 -DUSE_CUDA=ON -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc
+cmake --build build_cuda12 -j
+```
+
+### HIP (AMD GPUs)
+
+The HIP backend requires the ROCm Toolkit and a HIP-capable C++ compiler (`hipcc`) to be on `PATH`.  The default ROCm path is `/opt/rocm`, but this can be overriden with `-DHIP_PATH=<path>`.
+
+```bash
+cmake -B build_hip -DUSE_HIP=ON -DCMAKE_CXX_COMPILER=hipcc
+cmake --build build_hip -j
+```
+
+With a non-default ROCm installation:
+
+```bash
+cmake -B build_hip -DUSE_HIP=ON -DCMAKE_CXX_COMPILER=hipcc -DHIP_PATH=/opt/<rocm-custom>
+cmake --build build_hip -j
+```
+
+### OneAPI (Intel GPUs / SYCL)
+
+The OneAPI backend requires the OneAPI Toolkit and a SYCL-capable C++ compiler (`icpx`) to be on `PATH`. You can typically set `icpx` to be on your path using environment variables or the `setvars.sh` script included with OneAPI installations.
+
+```bash
+cmake -B build_oneapi -DUSE_ONEAPI=ON -DCMAKE_CXX_COMPILER=icpx
+cmake --build build_oneapi -j
+```
+
+---
+
+## Supported Compilers
+
+| Compiler | ID | Serial | OpenMP | CUDA | HIP | OneAPI |
+|---|---|:---:|:---:|:---:|:---:|:---:|
+| GCC | `GNU` | ✓ | ✓ | | | |
+| Clang | `Clang` | ✓ | ✓ | | | |
+| Intel (`icpx`) | `IntelLLVM` | ✓ | ✓ | | | ✓ |
+| Cray CCE | `Cray` | ✓ | ✓ | | | |
+| IBM XL | `XL` | ✓ | ✓ | | | |
+| NVCC | `NVIDIA` | | | ✓ | | |
+| `hipcc` | `ROCm (Clang)) | | | | ✓ | |
+
+---
+
+## Build Types
+
+The default build type is `Release`. To change it:
+
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=Debug
+```
+or 
+```bash
+cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
+```
+
+Debug builds include `-g -debug all`. GCC and Clang builds enable `-Wall -Wextra -Wconversion -pedantic-errors`.
+
+---

--- a/Build.md
+++ b/Build.md
@@ -1,144 +1,40 @@
-# Building Spatter
+# Supported configurations
 
-Spatter uses CMake (currently ≥ 3.25) and requires a C++17-compatible compiler.
+## Serial 
+### Supported Compilers
+* gnu
+* cray
 
-## Quick Start
+# Cuda 
+### Supported Compilers and optional arguments
+* nvcc
+    * `-DCUDA_ARCH=<ARCH>`
+        * Default is 7.0
+        * For example to set it to 7.0, enter `-DCUDA_ARCH=70`
 
-```bash
-cmake -B build [options]
-cmake --build build -j
-```
-
-The compiled `spatter` binary will be placed in the `build/` directory in this example.
-
-## Installation
-
-```bash
-cmake --install build --prefix /path/to/install
-```
-
-This installs the `spatter` and `gz_read` binaries to `<prefix>/bin/`.
-
-## Spack Installation
-You can also use Spack to install the default (OpenMP) and CUDA versions of Spatter. Please see the [Spack packages](https://packages.spack.io/package.html?name=spatter) for more information.
-
----
-
-## CMake Options
-
-| Option | Type | Default | Description |
-|---|---|---|---|
-| `USE_CUDA` | `BOOL` | `OFF` | Enable NVIDIA CUDA backend |
-| `USE_HIP` | `BOOL` | `OFF` | Enable AMD HIP/ROCm backend |
-| `USE_ONEAPI` | `BOOL` | `OFF` | Enable Intel OneAPI SYCL backend |
-| `USE_OPENMP` | `BOOL` | `OFF` | Enable OpenMP threading |
-| `USE_MPI` | `BOOL` | `OFF` | Enable MPI support |
-| `CMAKE_BUILD_TYPE` | `STRING` | `Release` | Build type: `Release`, `Debug`, `RelWithDebInfo` |
-| `CMAKE_CXX_COMPILER` | `STRING` | system default | C++ compiler to use |
-
-> **Note:** `USE_CUDA`, `USE_HIP`, and `USE_ONEAPI` are mutually exclusive. Only one GPU backend may be enabled at a time.
-
-## JSON Support
-JSON support via `nlohmann/json v3.11.2` is automatically fetched via CMake's `FetchContent`.
-
----
-
-## Backend Build Examples
-
-> **Note:** We recommend using the syntax `build_<backend>` to build Spatter backends, which makes it easier to distinguish different variants of the executable.
-
-
-### Serial (CPU only)
-
-Any supported C++ compiler works, and no backend flags are required.
-
-```bash
-cmake -B build
-cmake --build build -j
-```
-
-### OpenMP
-
-```bash
-cmake -B build_omp -DUSE_OPENMP=ON
-cmake --build build_omp -j
-```
-
-The OpenMP backend can be combined with the MPI backend:
-
-```bash
-cmake -B build_omp_mpi -DUSE_OPENMP=ON -DUSE_MPI=ON
-cmake --build build_omp_mpi -j
-```
-
-### CUDA (NVIDIA GPUs)
-
-The CUDA backend requires the CUDA Toolkit and a CUDA-capable compiler (`nvcc`) to be on `PATH`. CMake will auto-detect the installed CUDA toolkit.
-
-```bash
-cmake -B build_cuda -DUSE_CUDA=ON
-cmake --build build_cuda -j
-```
- If multiple CUDA versions are installed, you can point CMake at the preferred one as follows:
-
-```bash
-cmake -B build_cuda12 -DUSE_CUDA=ON -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc
-cmake --build build_cuda12 -j
-```
-
-### HIP (AMD GPUs)
-
-The HIP backend requires the ROCm Toolkit and a HIP-capable C++ compiler (`hipcc`) to be on `PATH`.  The default ROCm path is `/opt/rocm`, but this can be overriden with `-DHIP_PATH=<path>`.
-
-```bash
-cmake -B build_hip -DUSE_HIP=ON -DCMAKE_CXX_COMPILER=hipcc
-cmake --build build_hip -j
-```
-
-With a non-default ROCm installation:
-
-```bash
-cmake -B build_hip -DUSE_HIP=ON -DCMAKE_CXX_COMPILER=hipcc -DHIP_PATH=/opt/<rocm-custom>
-cmake --build build_hip -j
-```
-
-### OneAPI (Intel GPUs / SYCL)
-
-The OneAPI backend requires the OneAPI Toolkit and a SYCL-capable C++ compiler (`icpx`) to be on `PATH`. You can typically set `icpx` to be on your path using environment variables or the `setvars.sh` script included with OneAPI installations.
-
-```bash
-cmake -B build_oneapi -DUSE_ONEAPI=ON -DCMAKE_CXX_COMPILER=icpx
-cmake --build build_oneapi -j
-```
-
----
-
-## Supported Compilers
-
-| Compiler | ID | Serial | OpenMP | CUDA | HIP | OneAPI |
-|---|---|:---:|:---:|:---:|:---:|:---:|
-| GCC | `GNU` | ✓ | ✓ | | | |
-| Clang | `Clang` | ✓ | ✓ | | | |
-| Intel (`icpx`) | `IntelLLVM` | ✓ | ✓ | | | ✓ |
-| Cray CCE | `Cray` | ✓ | ✓ | | | |
-| IBM XL | `XL` | ✓ | ✓ | | | |
-| NVCC | `NVIDIA` | | | ✓ | | |
-| `hipcc` | `ROCm (Clang)) | | | | ✓ | |
-
----
-
-## Build Types
-
-The default build type is `Release`. To change it:
-
-```bash
-cmake -B build -DCMAKE_BUILD_TYPE=Debug
-```
-or 
-```bash
-cmake -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo
-```
-
-Debug builds include `-g -debug all`. GCC and Clang builds enable `-Wall -Wextra -Wconversion -pedantic-errors`.
-
----
+## Openmp
+### Supported Compilers and optional arguments
+* gnu
+    * `-DUSE_MPI=1`
+    * `-DSPATTER_ENABLE_NATIVE_ARCH=<ON|OFF>`
+        * Default is ON. Tunes the build for the host CPU (adds `-march=native`,
+          or `-mcpu=native` where `-march=native` is unsupported), so the
+          gather/scatter kernels are compiled for the host ISA (e.g. AVX2/AVX-512).
+        * Set to OFF for portable/reproducible binaries or when cross-compiling.
+    * `-DSPATTER_ARCH_FLAGS=<flags>`
+        * Pin a specific target instead of native detection,
+          e.g. `-DSPATTER_ARCH_FLAGS="-march=sapphirerapids"`. Takes precedence
+          over `SPATTER_ENABLE_NATIVE_ARCH`.
+* cray
+    * `-DUSE_PAPI=1`
+    * `-DUSE_SVE=1`
+* clang
+* armclang (wombat)
+* xl
+* intel
+    * `-DINTEL_PLATFORM=<PLATFORM>`
+        * skylake
+        * avx_crossplatform
+        * non_avx
+    * `-DUSE_MPI=1`
+    * `-DUSE_PAPI=1`

--- a/cmake/CompilerType.cmake
+++ b/cmake/CompilerType.cmake
@@ -25,6 +25,57 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
     set(SPAT_CXX_NAME "Clang")
 endif ()
 
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
+    set(SPAT_CXX_NAME "AppleClang")
+endif ()
+
+# ---------------------------------------------------------------------------
+# Host-architecture optimization for GNU/Clang.
+#
+# Spatter is a memory microbenchmark, so the compiler must target the ISA of
+# the machine actually being measured. The Intel compiler above already does
+# this with -xHost, but with GNU/Clang no architecture flag was being added,
+# so the compiler defaulted to the baseline x86-64 (SSE2) ISA and never
+# emitted AVX/AVX2/AVX-512 instructions in the gather/scatter kernels
+# (see issue #209).
+#
+# SPATTER_ENABLE_NATIVE_ARCH (default ON) adds the GNU/Clang equivalent of
+# -xHost. For reproducible or cross-compiled builds, either turn it OFF or
+# set SPATTER_ARCH_FLAGS to pin a specific target, e.g.
+#   -DSPATTER_ARCH_FLAGS="-march=sapphirerapids"
+# When SPATTER_ARCH_FLAGS is set it takes precedence and native detection is
+# skipped. Native tuning is also skipped automatically when cross-compiling.
+# ---------------------------------------------------------------------------
+option(SPATTER_ENABLE_NATIVE_ARCH "Tune the build for the host CPU architecture (GNU/Clang)" ON)
+set(SPATTER_ARCH_FLAGS "" CACHE STRING "Explicit architecture flags for GNU/Clang (overrides native detection), e.g. -march=native or -march=sapphirerapids")
+
+if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "^(GNU|Clang|AppleClang)$")
+    if (SPATTER_ARCH_FLAGS)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SPATTER_ARCH_FLAGS}")
+        message(STATUS "Using user-specified SPATTER_ARCH_FLAGS: ${SPATTER_ARCH_FLAGS}")
+    elseif (SPATTER_ENABLE_NATIVE_ARCH AND NOT CMAKE_CROSSCOMPILING)
+        include(CheckCXXCompilerFlag)
+        check_cxx_compiler_flag("-march=native" SPATTER_HAS_MARCH_NATIVE)
+        if (SPATTER_HAS_MARCH_NATIVE)
+            set(SPATTER_NATIVE_FLAG "-march=native")
+        else ()
+            # Apple/arm64 toolchains generally accept -mcpu=native instead.
+            check_cxx_compiler_flag("-mcpu=native" SPATTER_HAS_MCPU_NATIVE)
+            if (SPATTER_HAS_MCPU_NATIVE)
+                set(SPATTER_NATIVE_FLAG "-mcpu=native")
+            endif ()
+        endif ()
+        if (SPATTER_NATIVE_FLAG)
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SPATTER_NATIVE_FLAG}")
+            message(STATUS "Enabling host-native architecture tuning: ${SPATTER_NATIVE_FLAG}")
+        else ()
+            message(STATUS "No host-native architecture flag supported by this compiler; skipping")
+        endif ()
+    else ()
+        message(STATUS "Host-native architecture tuning disabled (SPATTER_ENABLE_NATIVE_ARCH=${SPATTER_ENABLE_NATIVE_ARCH}, CROSSCOMPILING=${CMAKE_CROSSCOMPILING})")
+    endif ()
+endif ()
+
 set (SPAT_CXX_VER ${CMAKE_CXX_COMPILER_VERSION})
 
 add_definitions(-DSPAT_CXX_NAME=${SPAT_CXX_NAME})


### PR DESCRIPTION
## Overview

Spatter is a memory microbenchmark, so its kernels need to be compiled for the ISA of the machine being measured. The Intel-compiler path already does this via `-xHost`, but the **GNU and Clang paths added no architecture flag at all**, so the compiler targeted the baseline `x86-64` (SSE2) ISA and never emitted AVX/AVX2/AVX-512 in the gather/scatter kernels. This is the behavior reported in #209, where `-mavx` had to be passed by hand to turn `movsd` into `vmovsd`.

Fixes #209.

## ✨ Change Description/Rationale

- `cmake/CompilerType.cmake` now adds the GNU/Clang equivalent of `-xHost`:
  - **`SPATTER_ENABLE_NATIVE_ARCH`** (default `ON`) adds `-march=native`, falling back to `-mcpu=native` on toolchains where `-march=native` is unsupported (e.g. Apple arm64). Detected with `check_cxx_compiler_flag`.
  - **`SPATTER_ARCH_FLAGS`** lets you pin an explicit target instead, e.g. `-DSPATTER_ARCH_FLAGS="-march=sapphirerapids"`. It takes precedence over native detection.
  - Native tuning is skipped automatically when cross-compiling (`CMAKE_CROSSCOMPILING`), and can be turned off with `-DSPATTER_ENABLE_NATIVE_ARCH=OFF` for portable/reproducible binaries.
- `Build.md` documents both options in the CMake Options table.

The design mirrors the existing Intel `-xHost` handling and keeps the default "fast on the machine you're benchmarking," while giving CI and packagers an explicit escape hatch for reproducible builds.

## Testing

- **Default build** reports `Enabling host-native architecture tuning: -march=native`, and the flag appears on the kernel compile line (`CXX_FLAGS = -march=native -O3 -DNDEBUG ... -fopenmp`).
- **Override** (`-DSPATTER_ARCH_FLAGS=...`) is used verbatim and native detection is skipped.
- **Disabled** (`-DSPATTER_ENABLE_NATIVE_ARCH=OFF`) reproduces the previous baseline flags exactly — no behavior change for anyone who wants it off.
- Full `cmake --build` succeeds and the resulting binary runs correctly (`./spatter -pUNIFORM:8:1 -l$((2**20))` gives expected bandwidth output).

To confirm the AVX codegen change on x86_64 (per #209):

```
objdump --disassemble=_ZN7Spatter13ConfigurationINS_6OpenMPEE7scatterEbm._omp_fn.0 ./build_openmp/spatter | grep -c vmov
# nonzero with the fix; 0 before
```

> Note: I verified the CMake logic, flag propagation, and a clean build/run locally on an aarch64 host (where the same "no arch flag" gap exists, and the fix selects `-mcpu=native`). The x86 `movsd`→`vmovsd` change is the one documented in #209.
